### PR TITLE
完成 btye[] 到 arraybuffer 的快速传递

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+cmake-*
+build64

--- a/unity/Assets/Puerts/Src/PuertsDLL.cs
+++ b/unity/Assets/Puerts/Src/PuertsDLL.cs
@@ -332,6 +332,47 @@ namespace Puerts
 
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetLogCallback(LogCallback log, LogCallback logWarning, LogCallback logError);
+        
+        
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void ReturnArrayBuffer(IntPtr isolate, IntPtr info, byte[] bytes, int Length);
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void PropertyReturnArrayBuffer(IntPtr isolate, IntPtr info, byte[] bytes, int Length);
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SetArrayBufferToOutValue(IntPtr isolate, IntPtr value, Byte[] bytes, int length);
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void PushArrayBufferForJSFunction(IntPtr function, byte[] bytes, int length);
+
+        public static Byte[] GetArrayListFromResult(IntPtr resultInfo)
+        {
+            int strlen;
+            IntPtr str = GetStringFromResult(resultInfo,out strlen);
+            string str2 = GetStringFromNative(str, strlen);
+            string[] str3 =  str2.Split(',');
+            Byte[] b = new Byte[str3.Length];
+            for(int i =0; i < str3.Length;i++)
+            {
+                b[i] = (Byte) int.Parse(str3[i]);
+            }
+
+            return b;
+        }
+        
+                
+        public static Byte[] GetArrayBufferFromValue(IntPtr isolate, IntPtr value, bool isByRef)
+        {
+            int strlen;
+            IntPtr str = GetStringFromValue(isolate, value, out strlen, isByRef);
+            string str2 = GetStringFromNative(str, strlen);
+            string[] str3 =  str2.Split(',');
+            Byte[] b = new Byte[str3.Length];
+            for(int i =0; i < str3.Length;i++)
+            {
+                b[i] = (Byte) int.Parse(str3[i]);
+            }
+
+            return b;
+        }
     }
 }
 

--- a/unity/Assets/Puerts/Src/PuertsDLL.cs
+++ b/unity/Assets/Puerts/Src/PuertsDLL.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using UnityEngine;
 
 namespace Puerts
 {
@@ -342,37 +343,40 @@ namespace Puerts
         public static extern void SetArrayBufferToOutValue(IntPtr isolate, IntPtr value, Byte[] bytes, int length);
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void PushArrayBufferForJSFunction(IntPtr function, byte[] bytes, int length);
-
-        public static Byte[] GetArrayListFromResult(IntPtr resultInfo)
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr GetArrayBufferFromValue(IntPtr isolate, IntPtr value, out int length, bool isOut);
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr GetArrayBufferFromResult(IntPtr function, out int length);
+        
+        private static byte[] GetArrayBufferFromNative(IntPtr ab, int strlen)
         {
-            int strlen;
-            IntPtr str = GetStringFromResult(resultInfo,out strlen);
-            string str2 = GetStringFromNative(str, strlen);
-            string[] str3 =  str2.Split(',');
-            Byte[] b = new Byte[str3.Length];
-            for(int i =0; i < str3.Length;i++)
+            if (ab != IntPtr.Zero)
             {
-                b[i] = (Byte) int.Parse(str3[i]);
+                int len = strlen;
+                byte[] buffer = new byte[len];
+                Marshal.Copy(ab, buffer, 0, len);
+                return buffer;
             }
-
-            return b;
+            else
+            {
+                return null;
+            }
         }
         
-                
-        public static Byte[] GetArrayBufferFromValue(IntPtr isolate, IntPtr value, bool isByRef)
+        public static byte[] GetArrayBufferFromValue(IntPtr isolate, IntPtr value, bool isByRef)
         {
             int strlen;
-            IntPtr str = GetStringFromValue(isolate, value, out strlen, isByRef);
-            string str2 = GetStringFromNative(str, strlen);
-            string[] str3 =  str2.Split(',');
-            Byte[] b = new Byte[str3.Length];
-            for(int i =0; i < str3.Length;i++)
-            {
-                b[i] = (Byte) int.Parse(str3[i]);
-            }
-
-            return b;
+            IntPtr str = GetArrayBufferFromValue(isolate, value, out strlen, isByRef);
+            return GetArrayBufferFromNative(str, strlen);
         }
+        
+        public static byte[] GetArrayBufferFromResult(IntPtr isolate, IntPtr value, bool isByRef)
+        {
+            int strlen;
+            IntPtr str = GetArrayBufferFromResult( value, out strlen);
+            return GetArrayBufferFromNative(str, strlen);
+        }
+
     }
 }
 

--- a/unity/native_src/Inc/JSFunction.h
+++ b/unity/native_src/Inc/JSFunction.h
@@ -33,7 +33,11 @@ struct FValue
             void *ObjectPtr;
             int ClassID;
         } ObjectInfo;
-        
+        struct
+        {
+            unsigned char *Bytes;
+            int Length;
+        } ArrayBuffer;
         class JSFunction *FunctionPtr;
     };
 };

--- a/unity/native_src/Inc/V8Utils.h
+++ b/unity/native_src/Inc/V8Utils.h
@@ -32,6 +32,7 @@ enum JsValueType
     Function        = 256,
     Date            = 512,
     Unknow          = 1024,
+    ArrayBuffer     = 2048
 };
 
 class FV8Utils

--- a/unity/native_src/Src/JSFunction.cpp
+++ b/unity/native_src/Src/JSFunction.cpp
@@ -38,7 +38,8 @@ namespace puerts
             return Value.FunctionPtr->GFunction.Get(Isolate);
         case Boolean:
             return v8::Boolean::New(Isolate, Value.Boolean);
-     
+        case ArrayBuffer:
+            return v8::ArrayBuffer::New(Isolate,Value.ArrayBuffer.Bytes,Value.ArrayBuffer.Length);
         default:
             return v8::Undefined(Isolate);
         }

--- a/unity/native_src/Src/Puerts.cpp
+++ b/unity/native_src/Src/Puerts.cpp
@@ -359,6 +359,17 @@ V8_EXPORT void ReleaseJSFunction(v8::Isolate* Isolate, JSFunction *Function)
     }
 }
 
+V8_EXPORT void SetArrayBufferToOutValue(v8::Isolate* Isolate, v8::Value *Value, unsigned char *Bytes, int Length)
+{
+    if (Value->IsObject())
+    {
+        auto Context = Isolate->GetCurrentContext();
+        auto Outer = Value->ToObject(Context).ToLocalChecked();
+        v8::Handle<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(Isolate,Bytes,Length);
+        auto ReturnVal = Outer->Set(Context, FV8Utils::V8String(Isolate, "value"),ab);
+    }
+}
+
 V8_EXPORT void ThrowException(v8::Isolate* Isolate, const char * Message)
 {
     FV8Utils::ThrowException(Isolate, Message);
@@ -399,6 +410,12 @@ V8_EXPORT void ReturnBoolean(v8::Isolate* Isolate, const v8::FunctionCallbackInf
 V8_EXPORT void ReturnDate(v8::Isolate* Isolate, const v8::FunctionCallbackInfo<v8::Value>& Info, double Date)
 {
     Info.GetReturnValue().Set(v8::Date::New(Isolate->GetCurrentContext(), Date).ToLocalChecked());
+}
+
+V8_EXPORT void ReturnArrayBuffer(v8::Isolate* Isolate, const v8::FunctionCallbackInfo<v8::Value>& Info, unsigned char *Bytes, int Length)
+{
+    v8::Handle<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(Isolate, Bytes, Length);
+    Info.GetReturnValue().Set(ab);
 }
 
 V8_EXPORT void ReturnNull(v8::Isolate* Isolate, const v8::FunctionCallbackInfo<v8::Value>& Info)
@@ -443,6 +460,15 @@ V8_EXPORT void PushBigIntForJSFunction(JSFunction *Function, int64_t V)
     FValue Value;
     Value.Type = puerts::BigInt;
     Value.BigInt = V;
+    Function->Arguments.push_back(Value);
+}
+
+V8_EXPORT void PushArrayBufferForJSFunction(JSFunction *Function, unsigned char * Bytes,int Length)
+{
+    FValue Value;
+    Value.Type = puerts::ArrayBuffer;
+    Value.ArrayBuffer.Length = Length;
+    Value.ArrayBuffer.Bytes = Bytes;
     Function->Arguments.push_back(Value);
 }
 
@@ -654,6 +680,11 @@ V8_EXPORT void PropertyReturnBigInt(v8::Isolate* Isolate, const v8::PropertyCall
 V8_EXPORT void PropertyReturnBoolean(v8::Isolate* Isolate, const v8::PropertyCallbackInfo<v8::Value>& Info, bool Bool)
 {
     Info.GetReturnValue().Set(Bool);
+}
+
+V8_EXPORT void PropertyReturnArrayBuffer(v8::Isolate* Isolate, const v8::PropertyCallbackInfo<v8::Value>& Info, unsigned char* Bytes, int Length)
+{
+    Info.GetReturnValue().Set(v8::ArrayBuffer::New(Isolate,Bytes,Length));
 }
 
 V8_EXPORT void PropertyReturnDate(v8::Isolate* Isolate, const v8::PropertyCallbackInfo<v8::Value>& Info, double Date)

--- a/unity/native_src/Src/Puerts.cpp
+++ b/unity/native_src/Src/Puerts.cpp
@@ -149,6 +149,24 @@ V8_EXPORT double GetNumberFromValue(v8::Isolate* Isolate, v8::Value *Value, bool
     }
 }
 
+V8_EXPORT const char* GetArrayBufferFromValue(v8::Isolate* Isolate, v8::Value *Value, int *Length,bool IsOut)
+{
+    if (IsOut)
+    {
+        auto Context = Isolate->GetCurrentContext();
+        auto Outer = Value->ToObject(Context).ToLocalChecked();
+        auto Realvalue = Outer->Get(Context, FV8Utils::V8String(Isolate, "value")).ToLocalChecked();
+        return GetArrayBufferFromValue(Isolate, *Realvalue,Length, false);
+    }
+    else
+    {
+
+        auto ab = v8::ArrayBuffer::Cast(Value);
+        *Length = ab->ByteLength();
+        return static_cast<char*>(ab->GetContents().Data());
+    }
+}
+
 V8_EXPORT void SetNumberToOutValue(v8::Isolate* Isolate, v8::Value *Value, double Number)
 {
     if (Value->IsObject())
@@ -570,6 +588,18 @@ V8_EXPORT const char *GetStringFromResult(FResultInfo *ResultInfo, int *Length)
     *Length = static_cast<int>(JsEngine->StrBuffer.length());
 
     return JsEngine->StrBuffer.c_str();
+}
+
+V8_EXPORT const char *GetArrayBufferFromResult(FResultInfo *ResultInfo, int *Length)
+{
+    v8::Isolate* Isolate = ResultInfo->Isolate;
+    v8::Isolate::Scope IsolateScope(Isolate);
+    v8::HandleScope HandleScope(Isolate);
+    v8::Local<v8::Context> Context = ResultInfo->Context.Get(Isolate);
+    v8::Context::Scope ContextScope(Context);
+    auto ab = v8::Local<v8::ArrayBuffer>::Cast(ResultInfo->Result.Get(Isolate));
+    *Length = ab->ByteLength();
+    return static_cast<char *>(ab->GetContents().Data());
 }
 
 V8_EXPORT bool GetBooleanFromResult(FResultInfo *ResultInfo)


### PR DESCRIPTION
不太懂得 GetArrayBufferFromValue 与 GetArrayBufferFromResult 如何获取到 byte[] 还有 length。
在 C# 写了一段代码。
```cs
        public static Byte[] GetArrayBufferFromValue(IntPtr isolate, IntPtr value, bool isByRef)
        {
            int strlen;
            IntPtr str = GetStringFromValue(isolate, value, out strlen, isByRef);
            string str2 = GetStringFromNative(str, strlen);
            string[] str3 =  str2.Split(',');
            Byte[] b = new Byte[str3.Length];
            for(int i =0; i < str3.Length;i++)
            {
                b[i] = (Byte) int.Parse(str3[i]);
            }

            return b;
        }
```
大概就是用获取String的方式获取 ArrayBuffer，然后按 , 分开转换成 byte。

希望可以 review 下其他代码。