### PR TITLE
修复 Timer 性能问题

### DIFF
--- a/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
+++ b/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
@@ -90,7 +90,6 @@ var global = global || (function () {
     const removing_timers = new Set();
     const timers = new PriorityQueue([], (a, b) => a.next_time - b.next_time);
     let next = 0;
-    let UnityEngine_Time = puerts.loadType('UnityEngine.Time');
     global.__tgjsRegisterTickHandler(() => {
         global_time = Date.now();
         timerUpdate();

--- a/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
+++ b/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
@@ -92,7 +92,7 @@ var global = global || (function () {
     let next = 0;
     let UnityEngine_Time = puerts.loadType('UnityEngine.Time');
     global.__tgjsRegisterTickHandler(() => {
-        global_time += UnityEngine_Time.deltaTime * 1000;
+        global_time = Date.now();
         timerUpdate();
     })
     global.__tgjsRegisterTickHandler = undefined;

--- a/unity/general/Src/UnitTest/TimerTest.cs
+++ b/unity/general/Src/UnitTest/TimerTest.cs
@@ -7,18 +7,21 @@
 
 using NUnit.Framework;
 
-namespace UnityEngine
-{
-    public class Time
-    {
-        public static double deltaTime = 0.1;
-    }
-}
-
 namespace Puerts.UnitTest
 {
+    class Timer
+    {
+        private int now = 0;
+
+        public int Now()
+        {
+            now += 100;
+            return now;
+        }
+    }
+    
     [TestFixture]
-    public class Timer
+    public class TimerTest
     {
         [OneTimeSetUp]
         public static void Init()
@@ -26,7 +29,6 @@ namespace Puerts.UnitTest
         }
 
         public static int SetTimeoutTestNum;
-
         [Test]
         public void SetTimeoutTest()
         {
@@ -35,7 +37,9 @@ namespace Puerts.UnitTest
 
             jsEnv.Eval(@"
                 const CS = require('csharp');
-                let obj = CS.Puerts.UnitTest.Timer;
+                let timer = new CS.Puerts.UnitTest.Timer();
+                Date.now = ()=>timer.Now();
+                let obj = CS.Puerts.UnitTest.TimerTest;
                 let i = 0;
                 setTimeout(()=>{obj.SetTimeoutTestNum = ++i;},4000);
             ");
@@ -50,7 +54,7 @@ namespace Puerts.UnitTest
                 {
                     Assert.AreEqual(1, SetTimeoutTestNum);
                 }
-
+                
                 jsEnv.Tick();
             }
 
@@ -68,7 +72,9 @@ namespace Puerts.UnitTest
 
             jsEnv.Eval(@"
                 const CS = require('csharp');
-                let obj = CS.Puerts.UnitTest.Timer;
+                let timer = new CS.Puerts.UnitTest.Timer();
+                Date.now = ()=>timer.Now();
+                let obj = CS.Puerts.UnitTest.TimerTest;
                 let i = 0;
                 setInterval(()=>{obj.SetIntervalTestNum = ++i;},1000);
             ");
@@ -91,7 +97,9 @@ namespace Puerts.UnitTest
 
             jsEnv.Eval(@"
                 const CS = require('csharp');
-                let obj = CS.Puerts.UnitTest.Timer;
+                let timer = new CS.Puerts.UnitTest.Timer();
+                Date.now = ()=>timer.Now();
+                let obj = CS.Puerts.UnitTest.TimerTest;
                 let i = 0;
                 let j = 0;
                 setInterval(()=>{obj.SetInterval2TestNum1 = ++i;},1000);
@@ -116,7 +124,9 @@ namespace Puerts.UnitTest
 
             jsEnv.Eval(@"
                 const CS = require('csharp');
-                let obj = CS.Puerts.UnitTest.Timer;
+                let timer = new CS.Puerts.UnitTest.Timer();
+                Date.now = ()=>timer.Now();
+                let obj = CS.Puerts.UnitTest.TimerTest;
                 let i = 0;
                 let id = setInterval(()=>{obj.TimerTest2Num = ++i;},500);
                 setTimeout(()=>{clearInterval(id);},2000);
@@ -147,7 +157,9 @@ namespace Puerts.UnitTest
 
             jsEnv.Eval(@"
                 const CS = require('csharp');
-                let obj = CS.Puerts.UnitTest.Timer;
+                let timer = new CS.Puerts.UnitTest.Timer();
+                Date.now = ()=>timer.Now();
+                let obj = CS.Puerts.UnitTest.TimerTest;
                 let i = 0;
                 let id = setInterval(()=>{obj.TimerTest3Num = ++i;},500);
                 setTimeout(()=>{clearInterval(id);},2000);
@@ -178,7 +190,9 @@ namespace Puerts.UnitTest
 
             jsEnv.Eval(@"
                 const CS = require('csharp');
-                let obj = CS.Puerts.UnitTest.Timer;
+                let timer = new CS.Puerts.UnitTest.Timer();
+                Date.now = ()=>timer.Now();
+                let obj = CS.Puerts.UnitTest.TimerTest;
                 let i = 0;
                 let id = setInterval(()=>{obj.TimerTest4Num = ++i;},500);
                 setTimeout(()=>{clearInterval(id);},200);


### PR DESCRIPTION
- 改用 `Date.now()` 替换原来的 `UnityEngine_Time.deltaTime`。
- 修改单元测试，Mock 了原来的 `Date.now()` 函数。