### PR TITLE
修复崩溃：不能在C#析构线程调用ReleaseJSFunction，延后到JSEnv的Tick中处理

### DIFF
--- a/unity/Assets/Puerts/Src/GenericDelegate.cs
+++ b/unity/Assets/Puerts/Src/GenericDelegate.cs
@@ -288,10 +288,7 @@ namespace Puerts
 #if THREAD_SAFE
             lock(jsEnv) {
 #endif
-            if (jsEnv.isolate != IntPtr.Zero)
-            {
-                PuertsDLL.ReleaseJSFunction(jsEnv.isolate, nativeJsFuncPtr);
-            }
+            jsEnv.EnqueueJSFunction(nativeJsFuncPtr);
 #if THREAD_SAFE
             }
 #endif


### PR DESCRIPTION
修复此问题：
https://github.com/chexiongsheng/puerts_unity_demo/issues/8