### PR TITLE
fix: Error Expected xxx.h to be first header included

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JSClassRegister.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JSClassRegister.cpp
@@ -5,9 +5,9 @@
 * This file is subject to the terms and conditions defined in file 'LICENSE', which is part of this source code package.
 */
 
-#include <map>
 #include "JSClassRegister.h"
 #include "UObject/Class.h"
+#include <map>
 
 namespace puerts
 {

--- a/unreal/Puerts/Source/JsEnv/Private/V8InspectorImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/V8InspectorImpl.cpp
@@ -11,26 +11,6 @@
 #define USING_UE 0
 #endif
 
-#if !USING_UE
-#if !defined(PLATFORM_WINDOWS) || defined(PLATFORM_MAC)
-#if defined(_WIN32)
-#define PLATFORM_WINDOWS 1
-#else
-#define PLATFORM_WINDOWS 0
-#if defined(__APPLE__)
-#include "TargetConditionals.h"
-#if TARGET_OS_IPHONE
-#define PLATFORM_MAC 0
-#else 
-#define PLATFORM_MAC 1
-#endif
-#else
-#define PLATFORM_MAC 0
-#endif
-#endif
-#endif
-#endif
-
 #if PLATFORM_WINDOWS || PLATFORM_MAC
 
 #include "V8InspectorImpl.h"


### PR DESCRIPTION
在新的UE工程中加入puerts插件后，编译时有如下错误：

Expected JSClassRegister.h to be first header included.
Expected V8InspectorImpl.h to be first header included.
