### PR TITLE
fixbug: Thirdparty module exports is empty when required in other files.

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/modular.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/modular.js
@@ -94,12 +94,12 @@ var global = global || (function () { return this; }());
                 let tmpRequire = genRequire(fullDirInJs);
                 let r = tmpRequire(packageConfigure.main);
                 tmpModuleStorage[sid] = undefined;
-                return r;
+                m.exports = r;
             } else {
                 executeModule(fullPath, script, debugPath, sid);
                 tmpModuleStorage[sid] = undefined;
-                return m.exports;
             }
+            return m.exports;
         }
 
         return require;


### PR DESCRIPTION
修复在一些文件中，多次导入第三方库时，报模块 undefined 的问题。