### PR TITLE
实现用户可以自定义全局函数的方法

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnv.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnv.cpp
@@ -26,7 +26,7 @@
 #include "JSClassRegister.h"
 #include "PromiseRejectCallback.hpp"
 
-#pragma warning(push, 0)  
+#pragma warning(push, 0)
 #include "libplatform/libplatform.h"
 #include "v8.h"
 #pragma warning(pop)
@@ -610,6 +610,9 @@ FJsEnvImpl::FJsEnvImpl(std::unique_ptr<IJSModuleLoader> InModuleLoader, std::sha
     DynamicInvoker->Parent = this;
 
     InitExtensionMethodsMap();
+
+	//注入用户自定义全局函数,这里必须在Global第一次Set之后,否则会出错
+	RegisterGlobalFunction(Isolate, Context, Global);
 
     if (InDebugPort >= 0)
     {
@@ -1990,7 +1993,7 @@ void FJsEnvImpl::LoadModule(const v8::FunctionCallbackInfo<v8::Value>& Info)
     FString OutDebugPath;
     TArray<uint8> Data;
     try
-    { 
+    {
         LoadFile(RequiringDir, ModuleName, OutPath, OutDebugPath, Data);
     }
     catch (const JSError& Err)

--- a/unreal/Puerts/Source/JsEnv/Public/JSClassRegister.h
+++ b/unreal/Puerts/Source/JsEnv/Public/JSClassRegister.h
@@ -9,7 +9,7 @@
 
 #include "CoreMinimal.h"
 
-#pragma warning(push, 0) 
+#pragma warning(push, 0)
 #include "v8.h"
 #pragma warning(pop)
 
@@ -51,13 +51,17 @@ typedef void(*AddonRegisterFunc)(v8::Isolate* Isolate, v8::Local<v8::Context> Co
 
 void JSENV_API RegisterClass(const JSClassDefinition &ClassDefinition);
 
-void RegisterAddon(const char* Name, AddonRegisterFunc RegisterFunc);
+void JSENV_API RegisterAddon(const char* Name, AddonRegisterFunc RegisterFunc);
+
+void JSENV_API RegisterGlobalAddon(AddonRegisterFunc RegisterFunc);
 
 const JSClassDefinition* FindClassByID(const char* Name);
 
 const JSClassDefinition* FindClassByType(UStruct* Type);
 
 const JSClassDefinition* FindCDataClassByName(const FString& Name);
+
+void RegisterGlobalFunction(v8::Isolate* Isolate, v8::Local<v8::Context> Context, v8::Local<v8::Object> Exports);
 
 AddonRegisterFunc FindAddonRegisterFunc(const FString& Name);
 }
@@ -71,3 +75,11 @@ AddonRegisterFunc FindAddonRegisterFunc(const FString& Name);
         }\
     } _AutoRegisterFor##Name
 
+#define PUERTS_GLOBAL_MODULE(RegFunc) \
+    static struct FAutoRegisterGlobal \
+    { \
+        FAutoRegisterGlobal()\
+        {\
+            puerts::RegisterGlobalAddon((RegFunc));\
+        }\
+    } _AutoRegisterGlobal


### PR DESCRIPTION
因为在创建另一个插件依赖Puerts时,如果使用PUERTS_MODULE这个宏定义的拓展模块,在加载时会发生错误,所以我拓展了一下方法,使得另一个插件可以定义全局的函数,或者变量,并且能够正常启动.

使用样例:

```
static v8::Local<v8::String> ToV8String(v8::Isolate* Isolate, const char* String)
{
	return v8::String::NewFromUtf8(Isolate, String,
	                               v8::NewStringType::kNormal).ToLocalChecked();
}

//自定义一个返回Promise的函数
static void Init(v8::Isolate* Isolate, v8::Local<v8::Context> Context, v8::Local<v8::Object> Exports)
{
	v8::Local<v8::Object> Global = Context->Global();
	Global->Set(Context, ToV8String(Isolate, "test"), v8::FunctionTemplate::New(Isolate, [](const v8::FunctionCallbackInfo<v8::Value>& Info)
	{
		auto* Isolate = Info.GetIsolate();
		auto Context = Isolate->GetCurrentContext();
		auto resolver = v8::Promise::Resolver::New(Context);
		Info.GetReturnValue().Set(resolver.ToLocalChecked()->GetPromise());
		resolver.ToLocalChecked()->Resolve(Context, v8::Undefined(Isolate));
	})->GetFunction(Context).ToLocalChecked()).Check();
}

PUERTS_GLOBAL_MODULE(Init);
```

typescript
```
test().then(e=>{});
```

测试插件在UE群共享的`RequestPlgun.zip`中