### PR TITLE
WIP)优化:避免直接使用World时,因为World未初始化导致的崩溃

### DIFF
--- a/unreal/Puerts/Content/TypeScript/react-umg/react-umg.ts
+++ b/unreal/Puerts/Content/TypeScript/react-umg/react-umg.ts
@@ -9,7 +9,7 @@ import * as Reconciler from 'react-reconciler'
 import * as puerts from 'puerts'
 import * as UE from 'ue'
 
-let world: UE.World;
+let instance: UE.GameInstance;
 
 function deepEquals(x: any, y: any) {
     if ( x === y ) return true;
@@ -285,16 +285,16 @@ const reconciler = Reconciler(hostConfig)
 
 export const ReactUMG = {
     render: function(reactElement: React.ReactNode) {
-        if (world == undefined) {
-            throw new Error("init with World first!");
+        if (!instance) {
+            throw new Error("init with GameInstance first!");
         }
-        let root = new UEWidgetRoot(UE.UMGManager.CreateReactWidget(world));
+        let root = new UEWidgetRoot(UE.UMGManager.CreateReactWidget(instance));
         const container = reconciler.createContainer(root, false, false);
         reconciler.updateContainer(reactElement, container, null, null);
         return root;
     },
-    init: function(inWorld: UE.World) {
-        world = inWorld;
+    init: function(inInstance: UE.GameInstance) {
+        instance = inInstance;
     }
 }
 

--- a/unreal/Puerts/Source/ReactUMG/UMGManager.cpp
+++ b/unreal/Puerts/Source/ReactUMG/UMGManager.cpp
@@ -10,14 +10,14 @@
 #include "Async/Async.h"
 
 
-UReactWidget* UUMGManager::CreateReactWidget(UWorld* World)
+UReactWidget* UUMGManager::CreateReactWidget(UGameInstance* Instance)
 {
-    return ::CreateWidget<UReactWidget>(World);
+    return ::CreateWidget<UReactWidget>(Instance);
 }
 
-UUserWidget* UUMGManager::CreateWidget(UWorld *World, UClass *Class)
+UUserWidget* UUMGManager::CreateWidget(UGameInstance* Instance, UClass* Class)
 {
-    return ::CreateWidget<UUserWidget>(World, Class);
+    return ::CreateWidget<UUserWidget>(Instance, Class);
 }
 
 void UUMGManager::SynchronizeWidgetProperties(UWidget* Widget)

--- a/unreal/Puerts/Source/ReactUMG/UMGManager.h
+++ b/unreal/Puerts/Source/ReactUMG/UMGManager.h
@@ -26,10 +26,10 @@ class REACTUMG_API UUMGManager : public UBlueprintFunctionLibrary
 public:
 
     UFUNCTION(BlueprintCallable, BlueprintCosmetic, Category = "Widget")
-    static UReactWidget* CreateReactWidget(UWorld* World);
+    static UReactWidget* CreateReactWidget(UGameInstance* Instance);
 
     UFUNCTION(BlueprintCallable, BlueprintCosmetic, Category = "Widget")
-    static UUserWidget* CreateWidget(UWorld* World, UClass* Class);
+    static UUserWidget* CreateWidget(UGameInstance* Instance, UClass* Class);
 
     UFUNCTION(BlueprintCallable, BlueprintCosmetic, Category = "Widget")
     static void SynchronizeWidgetProperties(UWidget* Widget);


### PR DESCRIPTION
使用UWorld创建UMG组件,在编译生产版本时,会崩溃(除非等待World开始播放后才没问题),如果使用GameInstance,就不会有问题,直接开始播放,避坑..



目前状态:还有有概率崩溃.