### PR TITLE
Code generation with UsingAction/Func

### DIFF
--- a/unity/Assets/Puerts/Src/Editor/Resources/puerts/templates/autoreg.tpl.txt
+++ b/unity/Assets/Puerts/Src/Editor/Resources/puerts/templates/autoreg.tpl.txt
@@ -4,7 +4,13 @@ namespace PuertsStaticWrap
     {
         public static void Register(Puerts.JsEnv jsEnv)
         {
-            {{~it :type}}jsEnv.AddLazyStaticWrapLoader(typeof({{=type.Name}}), {{=type.WrapClassName}}.GetRegisterInfo);
+        
+            {{~it.UsingActions :action}}jsEnv.UsingAction<{{=action}}>();
+            {{~}}
+            {{~it.UsingFunctions :func}}jsEnv.UsingFunc<{{=func}}>();
+            {{~}}
+            
+            {{~it.TypeGenInfos :type}}jsEnv.AddLazyStaticWrapLoader(typeof({{=type.Name}}), {{=type.WrapClassName}}.GetRegisterInfo);
             {{?type.BlittableCopy}}{{=type.WrapClassName}}.InitBlittableCopy(jsEnv);
             {{?}}{{~}}
         }


### PR DESCRIPTION
When creating the AutoStaticCodeRegister file, if necessary, define UsingAction/Func as well.

For example, if you execute code generation with this class

https://github.com/chexiongsheng/puerts_unity_demo/blob/master/Assets/Examples/03_Callback/TestClass.cs

JsEnv.UsingAction<int>() is automatically added to AutoStaticCodeRegister.