### PR TITLE
[unity]修改Generator.AddRefType,避免递归进入死循环

### DIFF
--- a/unity/Assets/Puerts/Src/Editor/Generator.cs
+++ b/unity/Assets/Puerts/Src/Editor/Generator.cs
@@ -761,6 +761,10 @@ namespace Puerts.Editor
         static void AddRefType(HashSet<Type> refTypes, Type type)
         {
             var rawType = GetRawType(type);
+			
+			//移动到此处进行判断, 避免递归进入死循环
+			if (refTypes.Contains(rawType) || type.IsPointer || rawType.IsPointer) return;
+			
             if (type.IsGenericType)
             {
                 foreach (var gt in type.GetGenericArguments())
@@ -768,7 +772,7 @@ namespace Puerts.Editor
                     AddRefType(refTypes, gt);
                 }
             }
-            if (refTypes.Contains(rawType) || type.IsPointer || rawType.IsPointer) return;
+            
             if (!rawType.IsGenericParameter)
             {
                 refTypes.Add(rawType);


### PR DESCRIPTION
将AddRefType函数中的过滤代码放到递归调用之前