### PR TITLE
强制转为绝对路径，避免watch找不到文件的问题

### DIFF
--- a/unreal/Puerts/Source/PuertsEditor/Private/FileSystemOperation.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/FileSystemOperation.cpp
@@ -55,7 +55,7 @@ void UFileSystemOperation::CreateDirectory(FString Path)
 
 FString UFileSystemOperation::GetCurrentDirectory()
 {
-    return FPaths::ProjectDir();
+    return FPaths::ConvertRelativePathToFull(FPaths::ProjectDir());
 }
 
 TArray<FString> UFileSystemOperation::GetDirectories(FString Path) 


### PR DESCRIPTION
(cherry picked from commit 61ebf07d9e7f7639d29a6c3b0ad2e347f3827f8b)