### PR TITLE
[unity] 修复: 在AddRefType中的循环引用和GenericArguments丢失

### DIFF
--- a/unity/Assets/Puerts/Src/Editor/Generator.cs
+++ b/unity/Assets/Puerts/Src/Editor/Generator.cs
@@ -764,10 +764,7 @@ namespace Puerts.Editor
             workTypes.Add(type);
 
             var rawType = GetRawType(type);
-			
-			//移动到此处进行判断, 避免递归进入死循环
-            if (refTypes.Contains(rawType) || type.IsPointer || rawType.IsPointer) return;
-			
+				
             if (type.IsGenericType)
             {
                 foreach (var gt in type.GetGenericArguments())
@@ -776,6 +773,7 @@ namespace Puerts.Editor
                 }
             }
             
+            if (refTypes.Contains(rawType) || type.IsPointer || rawType.IsPointer) return;
             if (!rawType.IsGenericParameter)
             {
                 refTypes.Add(rawType);

--- a/unity/Assets/Puerts/Src/Editor/Generator.cs
+++ b/unity/Assets/Puerts/Src/Editor/Generator.cs
@@ -760,6 +760,9 @@ namespace Puerts.Editor
 
         static void AddRefType(HashSet<Type> workTypes, HashSet<Type> refTypes, Type type)
         {
+            if(workTypes.Contains(type)) return;
+            workTypes.Add(type);
+
             var rawType = GetRawType(type);
 			
 			//移动到此处进行判断, 避免递归进入死循环

--- a/unity/Assets/Puerts/Src/Editor/Generator.cs
+++ b/unity/Assets/Puerts/Src/Editor/Generator.cs
@@ -758,7 +758,7 @@ namespace Puerts.Editor
             return false;
         }
 
-        static void AddRefType(HashSet<Type> refTypes, Type type)
+        static void AddRefType(HashSet<Type> workTypes, HashSet<Type> refTypes, Type type)
         {
             var rawType = GetRawType(type);
 			
@@ -769,7 +769,7 @@ namespace Puerts.Editor
             {
                 foreach (var gt in type.GetGenericArguments())
                 {
-                    AddRefType(refTypes, gt);
+                    AddRefType(workTypes, refTypes, gt);
                 }
             }
             
@@ -781,17 +781,17 @@ namespace Puerts.Editor
             if (IsDelegate(type) && type != typeof(Delegate) && type != typeof(MulticastDelegate))
             {
                 MethodInfo delegateMethod = type.GetMethod("Invoke");
-                AddRefType(refTypes, delegateMethod.ReturnType);
+                AddRefType(workTypes, refTypes, delegateMethod.ReturnType);
                 foreach (var pinfo in delegateMethod.GetParameters())
                 {
-                    AddRefType(refTypes, pinfo.ParameterType);
+                    AddRefType(workTypes, refTypes, pinfo.ParameterType);
                 }
             }
 
             var baseType = type.BaseType;
             while (baseType != null)
             {
-                AddRefType(refTypes, baseType);
+                AddRefType(workTypes, refTypes, baseType);
                 baseType = baseType.BaseType;
             }
             
@@ -894,36 +894,37 @@ namespace Puerts.Editor
         {
             HashSet<Type> genTypeSet = new HashSet<Type>();
 
+            HashSet<Type> workTypes = new HashSet<Type>();
             HashSet<Type> refTypes = new HashSet<Type>();
 
             foreach (var type in types)
             {
-                AddRefType(refTypes, type);
+                AddRefType(workTypes, refTypes, type);
                 var defType = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
                 if (!genTypeSet.Contains(defType)) genTypeSet.Add(defType);
                 foreach (var field in type.GetFields(Flags))
                 {
-                    AddRefType(refTypes, field.FieldType);
+                    AddRefType(workTypes, refTypes, field.FieldType);
                 }
 
                 foreach(var method in type.GetMethods(Flags))
                 {
-                    AddRefType(refTypes, method.ReturnType);
+                    AddRefType(workTypes, refTypes, method.ReturnType);
                     foreach(var pinfo in method.GetParameters())
                     {
-                        AddRefType(refTypes, pinfo.ParameterType);
+                        AddRefType(workTypes, refTypes, pinfo.ParameterType);
                     }
                 }
                 foreach(var constructor in type.GetConstructors())
                 {
                     foreach (var pinfo in constructor.GetParameters())
                     {
-                        AddRefType(refTypes, pinfo.ParameterType);
+                        AddRefType(workTypes, refTypes, pinfo.ParameterType);
                     }
                 }
             }
 
-            if (!genTypeSet.Contains(typeof(Array)) && !refTypes.Contains(typeof(Array))) AddRefType(refTypes, typeof(Array));
+            if (!genTypeSet.Contains(typeof(Array)) && !refTypes.Contains(typeof(Array))) AddRefType(workTypes, refTypes, typeof(Array));
 
             var tsTypeGenInfos = new Dictionary<string, TsTypeGenInfo>();
             foreach (var t in refTypes.Distinct())


### PR DESCRIPTION
配置:
``` cs
using System;
using System.Collections.Generic;
using Puerts;

[Configure]
public class PuertsConfigTest
{
    [Binding]
    static IEnumerable<Type> Binding
    {
        get
        {
            return new List<Type>()
            {
                typeof(BindingClass)
            };
        }
    }
}
public class BindingClass
{
    /**
    * [ERROR] Binding类型为List<>, 后续的List<T>类型未获取Type.GetGenericArguments直接退出
    */
    public List<ClassA> ClassA;
    public List<ClassB> ClassB;
    /**[ERROR] T参数在AddRefType中循环引用crash */
    public void Method<T>(Action<T> call) where T : GenericClass<T>
    {
    }
}
public class ClassA { }
public class ClassB { }
public abstract class GenericClass<T> where T : GenericClass<T> { }
```