### PR TITLE
修复TS蓝图生成时改变子蓝图覆写失效

### DIFF
--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -339,7 +339,7 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
         {
             //UE_LOG(LogTemp, Warning, TEXT("FunctionGraph %s existed, delete it!"), *InName.ToString());
             //FBlueprintEditorUtils::RemoveGraph(Blueprint, *ExistedGraph);
-	    FunctionGraph = *ExistedGraph;
+	        FunctionGraph = *ExistedGraph;
         }
         else 
         {
@@ -348,7 +348,7 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
                 InName, //FBlueprintEditorUtils::FindUniqueKismetName(Blueprint, FuncName.ToString()),
                 UEdGraph::StaticClass(),
                 UEdGraphSchema_K2::StaticClass());
-                FBlueprintEditorUtils::AddFunctionGraph<UClass>(Blueprint, FunctionGraph, bUserCreated, nullptr);
+            FBlueprintEditorUtils::AddFunctionGraph<UClass>(Blueprint, FunctionGraph, bUserCreated, nullptr);
         }
 
         //TODO: Add parameter

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -334,7 +334,7 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
         TArray< UEdGraph* > GraphList;
         Blueprint->GetAllGraphs(GraphList);
         UEdGraph** ExistedGraph = GraphList.FindByPredicate([&](UEdGraph* Graph) { return Graph->GetFName() == InName; });
-		UEdGraph* FunctionGraph;
+        UEdGraph* FunctionGraph;
         if (ExistedGraph)
         {
             //UE_LOG(LogTemp, Warning, TEXT("FunctionGraph %s existed, delete it!"), *InName.ToString());

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -459,7 +459,6 @@ void UPEBlueprintAsset::Save()
 {
     if (Blueprint && NeedSave)
     {
-        this->RemoveNotExistedFunction();
         FKismetEditorUtilities::CompileBlueprint(Blueprint);
 
         TArray<UPackage*> PackagesToSave;

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -384,7 +384,7 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
                 for (UK2Node_EditablePinBase* Node : TargetNodes)
                 {
                     Node->Modify();
-                    TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = EntryNode->UserDefinedPins;
+                    TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = Node->UserDefinedPins;
 					for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
 					{
 						Node->RemoveUserDefinedPin(pinInfo);

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -384,8 +384,8 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
                 for (UK2Node_EditablePinBase* Node : TargetNodes)
                 {
                     Node->Modify();
-                    TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = Node->UserDefinedPins;
-                    for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
+                    TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedReturnPins = Node->UserDefinedPins;
+                    for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedReturnPins)
                     {
                         Node->RemoveUserDefinedPin(pinInfo);
                     }

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -459,6 +459,7 @@ void UPEBlueprintAsset::Save()
 {
     if (Blueprint && NeedSave)
     {
+        this->RemoveNotExistedFunction();
         FKismetEditorUtilities::CompileBlueprint(Blueprint);
 
         TArray<UPackage*> PackagesToSave;

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -330,7 +330,7 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
     }
     else
     {
-        if (FunctionAdded.Contains(InName)) return;//����
+        if (FunctionAdded.Contains(InName)) return;
         TArray< UEdGraph* > GraphList;
         Blueprint->GetAllGraphs(GraphList);
         UEdGraph** ExistedGraph = GraphList.FindByPredicate([&](UEdGraph* Graph) { return Graph->GetFName() == InName; });
@@ -339,17 +339,17 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
         {
             //UE_LOG(LogTemp, Warning, TEXT("FunctionGraph %s existed, delete it!"), *InName.ToString());
             //FBlueprintEditorUtils::RemoveGraph(Blueprint, *ExistedGraph);
-			FunctionGraph = *ExistedGraph;
-		}
-		else 
+	    FunctionGraph = *ExistedGraph;
+        }
+        else 
         {
-			FunctionGraph = FBlueprintEditorUtils::CreateNewGraph(
-				Blueprint,
-				InName, //FBlueprintEditorUtils::FindUniqueKismetName(Blueprint, FuncName.ToString()),
-				UEdGraph::StaticClass(),
-				UEdGraphSchema_K2::StaticClass());
-			FBlueprintEditorUtils::AddFunctionGraph<UClass>(Blueprint, FunctionGraph, bUserCreated, nullptr);
-		}
+            FunctionGraph = FBlueprintEditorUtils::CreateNewGraph(
+                Blueprint,
+                InName, //FBlueprintEditorUtils::FindUniqueKismetName(Blueprint, FuncName.ToString()),
+                UEdGraph::StaticClass(),
+                UEdGraphSchema_K2::StaticClass());
+                FBlueprintEditorUtils::AddFunctionGraph<UClass>(Blueprint, FunctionGraph, bUserCreated, nullptr);
+        }
 
         //TODO: Add parameter
         TArray<UK2Node_FunctionEntry*> EntryNodes;
@@ -362,11 +362,11 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
             //EntryNodes[0]->CreateUserDefinedPin(TEXT("P1"), StringPinType, EGPD_Output);
             //EntryNodes[0]->CreateUserDefinedPin(TEXT("P2"), ActorPinType, EGPD_Input, false);
             UK2Node_FunctionEntry* EntryNode = EntryNodes[0];
-			TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = EntryNode->UserDefinedPins;
-			for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
-			{
-				EntryNode->RemoveUserDefinedPin(pinInfo);
-			}
+            TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = EntryNode->UserDefinedPins;
+            for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
+            {
+                EntryNode->RemoveUserDefinedPin(pinInfo);
+            }
             for (int i = 0; i < ParameterNames.Num(); i++)
             {
                 EntryNodes[0]->CreateUserDefinedPin(ParameterNames[i], ParameterTypes[i], EGPD_Output);
@@ -385,10 +385,10 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
                 {
                     Node->Modify();
                     TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = Node->UserDefinedPins;
-					for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
-					{
-						Node->RemoveUserDefinedPin(pinInfo);
-					}
+                    for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
+                    {
+                        Node->RemoveUserDefinedPin(pinInfo);
+                    }
                     Node->CreateUserDefinedPin(RetValName, PinType, EGPD_Input, false);
                 }
             }

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -330,24 +330,26 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
     }
     else
     {
-        if (FunctionAdded.Contains(InName)) return;//ÖØÔØ
+        if (FunctionAdded.Contains(InName)) return;//ï¿½ï¿½ï¿½ï¿½
         TArray< UEdGraph* > GraphList;
         Blueprint->GetAllGraphs(GraphList);
         UEdGraph** ExistedGraph = GraphList.FindByPredicate([&](UEdGraph* Graph) { return Graph->GetFName() == InName; });
+		UEdGraph* FunctionGraph;
         if (ExistedGraph)
         {
             //UE_LOG(LogTemp, Warning, TEXT("FunctionGraph %s existed, delete it!"), *InName.ToString());
-            FBlueprintEditorUtils::RemoveGraph(Blueprint, *ExistedGraph);
-        }
-
-        //UE_LOG(LogTemp, Warning, TEXT("Add Function %s"), *InName.ToString());
-        UEdGraph* FunctionGraph = FBlueprintEditorUtils::CreateNewGraph(
-            Blueprint,
-            InName, //FBlueprintEditorUtils::FindUniqueKismetName(Blueprint, FuncName.ToString()),
-            UEdGraph::StaticClass(),
-            UEdGraphSchema_K2::StaticClass());
-
-        FBlueprintEditorUtils::AddFunctionGraph<UClass>(Blueprint, FunctionGraph, bUserCreated, nullptr);
+            //FBlueprintEditorUtils::RemoveGraph(Blueprint, *ExistedGraph);
+			FunctionGraph = *ExistedGraph;
+		}
+		else 
+        {
+			FunctionGraph = FBlueprintEditorUtils::CreateNewGraph(
+				Blueprint,
+				InName, //FBlueprintEditorUtils::FindUniqueKismetName(Blueprint, FuncName.ToString()),
+				UEdGraph::StaticClass(),
+				UEdGraphSchema_K2::StaticClass());
+			FBlueprintEditorUtils::AddFunctionGraph<UClass>(Blueprint, FunctionGraph, bUserCreated, nullptr);
+		}
 
         //TODO: Add parameter
         TArray<UK2Node_FunctionEntry*> EntryNodes;
@@ -359,6 +361,12 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
             //FEdGraphPinType ActorPinType(UEdGraphSchema_K2::PC_Object, NAME_None, AActor::StaticClass(), EPinContainerType::None, false, FEdGraphTerminalType());
             //EntryNodes[0]->CreateUserDefinedPin(TEXT("P1"), StringPinType, EGPD_Output);
             //EntryNodes[0]->CreateUserDefinedPin(TEXT("P2"), ActorPinType, EGPD_Input, false);
+            UK2Node_FunctionEntry* EntryNode = EntryNodes[0];
+			TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = EntryNode->UserDefinedPins;
+			for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
+			{
+				EntryNode->RemoveUserDefinedPin(pinInfo);
+			}
             for (int i = 0; i < ParameterNames.Num(); i++)
             {
                 EntryNodes[0]->CreateUserDefinedPin(ParameterNames[i], ParameterTypes[i], EGPD_Output);
@@ -376,6 +384,11 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
                 for (UK2Node_EditablePinBase* Node : TargetNodes)
                 {
                     Node->Modify();
+                    TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = EntryNode->UserDefinedPins;
+					for (TSharedPtr<FUserPinInfo> pinInfo : OldUserDefinedPins)
+					{
+						Node->RemoveUserDefinedPin(pinInfo);
+					}
                     Node->CreateUserDefinedPin(RetValName, PinType, EGPD_Input, false);
                 }
             }


### PR DESCRIPTION
本commit用于修复：https://github.com/Tencent/puerts/issues/173
原因：每次更新蓝图生成的时候，puertsEditor实际上会删除function graph并重新建立新graph，每次建立新graph应该会导致id的改变从而让子蓝图失效。
更改：不再删除旧蓝图，而是根据旧蓝图重建function，具体操作是，删除原有的pin，再重新添加pin
测试：在UE4.24上，issue 173无法再次复现