### PR TITLE
处理日志输出可能导致引擎运行中断

### DIFF
--- a/unity/Assets/Puerts/Src/Resources/puerts/log.js.txt
+++ b/unity/Assets/Puerts/Src/Resources/puerts/log.js.txt
@@ -17,7 +17,13 @@ var global = global || (function () { return this; }());
     var console = {}
 
     function toString(args) {
-        return Array.prototype.map.call(args, x => x === null? "null": x === undefined ? 'undefined' : x.toString()).join(',');
+        return Array.prototype.map.call(args, x => {
+            try {
+                return x.toString();
+            } catch (err) {
+                return err;
+            }
+        }).join(',');
     }
 
     console.log = function() {


### PR DESCRIPTION
由于一些数据其原型链上无 toString 方法，会导致日志输出时转换为文本时出错

增加容错处理，出错的话抛出 error 信息