### PR TITLE
feat: 支持通过 self 引用全局 this

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/modular.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/modular.js
@@ -60,7 +60,12 @@ var global = global || (function () { return this; }());
         let wrapped = evalScript(
             // Wrap the script in the same way NodeJS does it. It is important since IDEs (VSCode) will use this wrapper pattern
             // to enable stepping through original source in-place.
-            "(function (exports, require, module, __filename, __dirname) { " + script + "\n});", 
+            `(function() {
+                let self = this;
+                return (function (exports, require, module, __filename, __dirname) {
+                    ${script}
+                });
+            }).call(this)`,
             debugPath
         )
         wrapped(exports, puerts.genRequire(fullDirInJs), module, fullPathInJs, fullDirInJs)


### PR DESCRIPTION
由于在 strict mode 中，匿名函数内部无法引用到全局的 this，因此在一些场合会造成不便。典型地，在 protobufjs 中存在如下的逻辑：

```javascript
// protobufjs\src\util\minimal.js:44
util.global = util.isNode && global
           || typeof window !== "undefined" && window
           || typeof self   !== "undefined" && self
           || this; // eslint-disable-line no-invalid-this
```

由于在匿名函数中执行这段代码，因此 `this` 是 `undefined`，后续的操作中会导致异常。因此在这个 commit 中增加了一个 `self` 来方便内部的代码引用全局 `this`。