### PR TITLE
I can't pass the null object to JS with ResultHelper.Set<T>() function.

### DIFF
--- a/unity/Assets/Puerts/Src/ArgumentHelper.cs
+++ b/unity/Assets/Puerts/Src/ArgumentHelper.cs
@@ -236,9 +236,20 @@ namespace Puerts
 
     public struct ResultHelper
     {
-        public static void Set<T>(int jsEnvIdx, IntPtr isolate, IntPtr info, T result)
+        public static void Set<T>(int jsEnvIdx, IntPtr isolate, IntPtr info, T result, bool isNullValue = false)
         {
-            StaticTranslate<T>.Set(jsEnvIdx, isolate, NativeValueApi.SetValueToResult, info, result);
+            // Generic function issue.
+            // If pass the null value to the generic function, the parameter is not null and it is a default value.
+            // Explicitly pass <null or not> together. (isNullValue)
+            if (isNullValue)
+            {
+                // TODO : need to make a code in a prettier way.
+                Set(jsEnvIdx, isolate, info, Puerts.JsValueType.NullOrUndefined);
+            }
+            else
+            {
+                StaticTranslate<T>.Set(jsEnvIdx, isolate, NativeValueApi.SetValueToResult, info, result);
+            }
         }
     }
 }

--- a/unity/Assets/Puerts/Src/Editor/Generator.cs
+++ b/unity/Assets/Puerts/Src/Editor/Generator.cs
@@ -93,6 +93,7 @@ namespace Puerts.Editor
             public ParameterGenInfo[] ParameterInfos;
             public bool IsVoid;
             public bool HasParams;
+            public bool IsNullableReturn;
         }
 
         public class MethodGenInfo
@@ -252,7 +253,8 @@ namespace Puerts.Editor
                 {
                     ParameterInfos = methodInfo.GetParameters().Select(info => ToParameterGenInfo(info)).ToArray(),
                     TypeName = RemoveRefAndToConstraintType(methodInfo.ReturnType).GetFriendlyName(),
-                    IsVoid = methodInfo.ReturnType == typeof(void)
+                    IsVoid = methodInfo.ReturnType == typeof(void),
+                    IsNullableReturn = Utils.IsNullableType(methodInfo.ReturnType)
                 };
                 FillEnumInfo(mainInfo, methodInfo.ReturnType);
                 mainInfo.HasParams = mainInfo.ParameterInfos.Any(info => info.IsParams);

--- a/unity/Assets/Puerts/Src/Editor/Resources/puerts/templates/type.tpl.txt
+++ b/unity/Assets/Puerts/Src/Editor/Resources/puerts/templates/type.tpl.txt
@@ -107,6 +107,8 @@ function setReturn(typeInfo) {
         return fixReturn[typeName];
     } else if (typeInfo.IsEnum) {
         return fixReturn[typeInfo.UnderlyingTypeName].replace('result', `(${typeInfo.UnderlyingTypeName})result`);
+    } else if (typeInfo.IsNullableReturn) {
+        return `Puerts.ResultHelper.Set((int)data, isolate, info, result, (result == null))`;
     } else {
         return `Puerts.ResultHelper.Set((int)data, isolate, info, result)`;
     }

--- a/unity/Assets/Puerts/Src/Utils.cs
+++ b/unity/Assets/Puerts/Src/Utils.cs
@@ -72,5 +72,14 @@ namespace Puerts
             }
             return hasValidGenericParameter && returnTypeValid;
         }
+
+        public static bool IsNullableType(Type type)
+        {
+            if (!type.IsValueType) return true; // ref-type
+
+            if (Nullable.GetUnderlyingType(type) != null) return true; // Nullable<T>
+
+            return false; // value-type
+        }
     }
 }


### PR DESCRIPTION
Hello,

When I used ResultHelper.Set<T>() function, I can't pass the null value to JS.
Because of "Set<T>" function is generic, and It didn't allow the nullable.
For example, I called a _Set_ funtion with null value like below code.
`Puerts.ResultHelper.Set((int)data, isolate, info, null);`

But the last _null_ parameter is not null in the **Set** function.
```
public static void Set<T>(int jsEnvIdx, IntPtr isolate, IntPtr info, T result)
{
    // 'result' is not a null. It is default of T.
    StaticTranslate<T>.Set(jsEnvIdx, isolate, NativeValueApi.SetValueToResult, info, result);
}
```

So, I need to change the code for explicitly pass <null or not> together.
```
public static void Set<T>(int jsEnvIdx, IntPtr isolate, IntPtr info, T result, bool isNullValue = false)
{
    // Generic function issue.
    // If pass the null value to the generic function, the parameter is not null and it is a default value.
    // Explicitly pass <null or not> together. (isNullValue)
    if (isNullValue)
    {
        // TODO : need to make a code in a prettier way.
        Set(jsEnvIdx, isolate, info, Puerts.JsValueType.NullOrUndefined);
    }
    else
    {
        StaticTranslate<T>.Set(jsEnvIdx, isolate, NativeValueApi.SetValueToResult, info, result);
    }
}
```

It is helpful for Unity developers.

For example,
When someone generated wrapper code for GameObject before.
If the person call GetComponent(A) to GameObject that doesn't contain the A component,
That function will be return exact null and it can check component by null in JS.

So, please check the issue.
Thanks.
