### PR TITLE
fixed: CallFunction为None时的编辑器崩溃问题.

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.cpp
@@ -207,6 +207,8 @@ void FFunctionTranslator::Call(v8::Isolate* Isolate, v8::Local<v8::Context>& Con
 #else
     void *Params = ParamsBufferSize > 0 ? FMemory_Alloca(ParamsBufferSize) : nullptr;
 #endif
+    
+    if (CallFunction->GetName() == "None") return;
 
     if (Params) CallFunction->InitializeStruct(Params);
     for (int i = 0; i < Arguments.size(); ++i)


### PR DESCRIPTION
UE4.26 编辑器模式下，偶尔会出现CallFunction为None的编辑器崩溃问题
### 异常状态
> 文件: FunctionTranslator.cpp

![image](https://user-images.githubusercontent.com/36908656/120271579-27ba9680-c2de-11eb-8d6e-1aeb0abc7db4.png)
