### PR TITLE
WaitDebugger增加超时参数

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnv.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnv.cpp
@@ -32,9 +32,9 @@ void FJsEnv::LowMemoryNotification()
     GameScript->LowMemoryNotification();
 }
 
-void FJsEnv::WaitDebugger()
+void FJsEnv::WaitDebugger(double timeout)
 {
-    GameScript->WaitDebugger();
+    GameScript->WaitDebugger(timeout);
 }
 
 void FJsEnv::TryBindJs(const class UObjectBase *InObject)

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -51,9 +51,20 @@ public:
 
     void LowMemoryNotification() override;
 
-    void WaitDebugger() override
+    void WaitDebugger(double timeout) override
     {
-        while (Inspector && !Inspector->Tick()) {}
+        const auto startTime = FDateTime::Now();
+        while (Inspector && !Inspector->Tick())
+        {
+            if (timeout > 0)
+            {
+                auto now = FDateTime::Now();
+                if ((now - startTime).GetTotalSeconds() >= timeout)
+                {
+                    break;
+                }
+            }
+        }
     }
 
     virtual void TryBindJs(const class UObjectBase *InObject) override;

--- a/unreal/Puerts/Source/JsEnv/Public/JsEnv.h
+++ b/unreal/Puerts/Source/JsEnv/Public/JsEnv.h
@@ -30,7 +30,7 @@ public:
 
     virtual void LowMemoryNotification() = 0;
 
-    virtual void WaitDebugger() = 0;
+    virtual void WaitDebugger(double timeout) = 0;
 
     virtual void TryBindJs(const class UObjectBase *InObject) = 0;
 
@@ -57,7 +57,7 @@ public:
 
     void LowMemoryNotification();
 
-    void WaitDebugger();
+    void WaitDebugger(double timeout = 0);
 
     void TryBindJs(const class UObjectBase *InObject);
 

--- a/unreal/Puerts/Source/Puerts/Private/PuertsModule.cpp
+++ b/unreal/Puerts/Source/Puerts/Private/PuertsModule.cpp
@@ -204,7 +204,7 @@ public:
 
             if (Settings.WaitDebugger)
             {
-                JsEnv->WaitDebugger();
+                JsEnv->WaitDebugger(Settings.WaitDebuggerTimeout);
             }
 
             JsEnv->RebindJs();
@@ -291,6 +291,7 @@ void FPuertsModule::RegisterSettings()
         GConfig->GetBool(SectionName, TEXT("AutoModeEnable"), Settings.AutoModeEnable, PuertsConfigIniPath);
         GConfig->GetBool(SectionName, TEXT("DebugEnable"), Settings.DebugEnable, PuertsConfigIniPath);
         GConfig->GetBool(SectionName, TEXT("WaitDebugger"), Settings.WaitDebugger, PuertsConfigIniPath);
+        GConfig->GetDouble(SectionName, TEXT("WaitDebuggerTimeout"), Settings.WaitDebuggerTimeout, PuertsConfigIniPath);
         if (!GConfig->GetInt(SectionName, TEXT("DebugPort"), Settings.DebugPort, PuertsConfigIniPath))
         {
             Settings.DebugPort = 8080;

--- a/unreal/Puerts/Source/Puerts/Private/PuertsSetting.h
+++ b/unreal/Puerts/Source/Puerts/Private/PuertsSetting.h
@@ -31,6 +31,9 @@ public:
     UPROPERTY(config, EditAnywhere, Category = "Setting", meta = (DisplayName = "Wait Debugger", defaultValue = false))
     bool WaitDebugger = false;
 
+	UPROPERTY(config, EditAnywhere, Category = "Setting", meta = (DisplayName = "Wait Debugger Timeout", defaultValue = 0))
+	double WaitDebuggerTimeout = 0;
+	
     UPROPERTY(config, EditAnywhere, Category = "Setting", meta = (DisplayName = "Number of JavaScript Env", defaultValue = 1))
     int32 NumberOfJsEnv = 1;
 };


### PR DESCRIPTION
WaitDebugger增加超时参数，单位为秒。如果超过时间没有调试器连接上来将放行线程避免一直处于卡死状态。
默认值为0，表示无超时处理与原有行为一致