### PR TITLE
[unreal]Add 'Puerts.Gen' console command

### DIFF
--- a/doc/unreal/manual.md
+++ b/doc/unreal/manual.md
@@ -106,6 +106,8 @@ class TS_Player extends UE.Character {
 
 ![puerts_gen_dts.png](../../pic/puerts_gen_dts.png)
 
+* 或者，也可以通过控制台命令生成声明文件：`Puerts.Gen`
+    - 注：UE5 EA版的工具栏扩展按钮目前无法使用，故可用这种方式替代。
 ### 成员及函数
 
 ~~~typescript

--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -689,6 +689,7 @@ class FDeclarationGenerator : public IDeclarationGenerator
 {
 private:
     TSharedPtr<class FUICommandList> PluginCommands;
+	TUniquePtr<FAutoConsoleCommand> ConsoleCommand;
 
     void AddToolbarExtension(FToolBarBuilder& Builder)
     {
@@ -746,6 +747,10 @@ public:
 
             LevelEditorModule.GetToolBarExtensibilityManager()->AddExtender(ToolbarExtender);
         }
+
+		ConsoleCommand = MakeUnique<FAutoConsoleCommand>(TEXT("Puerts.Gen")
+			, TEXT("Execute GenDTS action")
+			, FConsoleCommandDelegate::CreateRaw(this, &FDeclarationGenerator::GenUeDts));
     }
 
     void ShutdownModule() override 


### PR DESCRIPTION
增加生成TS声明文件的控制台命令：Puerts.Gen
UE5 EA版的工具栏扩展按钮目前不可用，可通过此命令替代。