### PR TITLE
[unreal]Fix GC crash of JsEnv delegate

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -382,8 +382,8 @@ private:
         MulticastDelegatePropertyMacro *MulticastDelegateProperty;
         UFunction *SignatureFunction;
         bool PassByPointer;
-        UDynamicDelegateProxy *Proxy;//for delegate
-        TSet<UDynamicDelegateProxy*> Proxys; // for MulticastDelegate
+        TWeakObjectPtr<UDynamicDelegateProxy> Proxy;//for delegate
+        TSet<TWeakObjectPtr<UDynamicDelegateProxy>> Proxys; // for MulticastDelegate
     };
 
     struct TsFunctionInfo


### PR DESCRIPTION
在Win64 Debug版本中，开启自动绑定模式时，FJsEnvImpl析构函数清理DelegateMap处存在崩溃，
经检查是由于UObject GC问题所致。
故采用TWeakObjectPtr对指针进行保护。