### PR TITLE
[unity]建议优化C# Wrap层中ArgumentHelper构造函数中非必要的JsValueType获取#316 

### DIFF
--- a/unity/Assets/Puerts/Src/ArgumentHelper.cs
+++ b/unity/Assets/Puerts/Src/ArgumentHelper.cs
@@ -14,7 +14,7 @@ namespace Puerts
         private readonly int jsEnvIdx;
         private readonly IntPtr isolate;
         private readonly IntPtr value;
-        private readonly JsValueType valueType;
+        private JsValueType valueType;
         private object obj;
         private Type csType;
 
@@ -23,13 +23,15 @@ namespace Puerts
             this.jsEnvIdx = jsEnvIdx;
             this.isolate = isolate;
             value = PuertsDLL.GetArgumentValue(info, index);
-            valueType = PuertsDLL.GetJsValueType(isolate, value, false);
+            valueType = JsValueType.Invalid;
             obj = null;
             csType = null;
         }
 
         public bool IsMatch(JsValueType expectJsType, Type expectCsType, bool isByRef, bool isOut)
         {
+            if (this.valueType == JsValueType.Invalid)
+                this.valueType = PuertsDLL.GetJsValueType(isolate, value, false);
             var jsType = this.valueType;
             if (jsType == JsValueType.JsObject)
             {

--- a/unity/Assets/Puerts/Src/PuertsDLL.cs
+++ b/unity/Assets/Puerts/Src/PuertsDLL.cs
@@ -45,6 +45,7 @@ namespace Puerts
     [Flags]
     public enum JsValueType
     {
+        Invalid = 0,
         NullOrUndefined = 1,
         BigInt = 2,
         Number = 4,


### PR DESCRIPTION
优化C# Wrap层中ArgumentHelper构造函数中非必要的JsValueType获取，用到时再获取，减少与c++胶水层的交互次数 #316 