### PR TITLE
[Unity]优化timer.js中每帧timerUpdate函数中的DateNow消耗

### DIFF
--- a/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
+++ b/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
@@ -93,10 +93,13 @@ var global = global || (function () {
     delete global.__tgjsRegisterTickHandler;
 
     function timerUpdate() {
-        const now = Date.now();
         while (true) {
             const time = timers.peek();
-            if (time && time.next_time <= now) {
+            if (!time) {
+               break;
+            }
+            const now = Date.now();
+            if (time.next_time <= now) {
                 timers.pop();
                 if(removing_timers.has(time.id)){
                     removing_timers.delete(time.id)
@@ -108,9 +111,9 @@ var global = global || (function () {
                     }
                     time.handler(time.args);
                 }
-
-            } else {
-                break;
+            }
+            else {
+               break;
             }
         }
     }

--- a/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
+++ b/unity/Assets/Puerts/Src/Resources/puerts/timer.js.txt
@@ -93,26 +93,27 @@ var global = global || (function () {
     delete global.__tgjsRegisterTickHandler;
 
     function timerUpdate() {
+        let now = null;
         while (true) {
             const time = timers.peek();
             if (!time) {
                break;
             }
-            const now = Date.now();
+            if (!now){
+                now = Date.now();
+            }
             if (time.next_time <= now) {
                 timers.pop();
                 if(removing_timers.has(time.id)){
-                    removing_timers.delete(time.id)
-                }
-                else {
+                    removing_timers.delete(time.id);
+                } else {
                     if (time.timeout) {
                         time.next_time = now + time.timeout;
                         timers.push(time);
                     }
                     time.handler(time.args);
                 }
-            }
-            else {
+            } else {
                break;
             }
         }


### PR DESCRIPTION
修改为用到时再去取当前时间，没有定时器时不获取