### PR TITLE
[unreal]使TS中支持Reliable RPC

### DIFF
--- a/doc/unreal/manual.md
+++ b/doc/unreal/manual.md
@@ -498,7 +498,7 @@ class TsTestActor extends UE.Actor {
 
     }
 
-    @rpc.flags(rpc.FunctionFlags.FUNC_Net | rpc.FunctionFlags.FUNC_NetServer)
+    @rpc.flags(rpc.FunctionFlags.FUNC_Net | rpc.FunctionFlags.FUNC_NetServer | rpc.FunctionFlags.FUNC_NetReliable)
     FireServer(): void {
 
     }

--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -157,6 +157,7 @@ var global = global || (function () { return this; }());
     
     const FunctionFlags = {
         "FUNC_Net"              : 0x00000040,   // Function is network-replicated.
+        "FUNC_NetReliable"      : 0x00000080,   // Function should be sent reliably on the network.
         "FUNC_NetMulticast"     : 0x00004000,	// Function is networked multicast Server -> All Clients
         "FUNC_NetServer"        : 0x00200000,	// Function is executed on servers (set by replication code if passes check)
         "FUNC_NetClient"        : 0x01000000,	// function is executed on clients

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Tencent is pleased to support the open source community by making Puerts available.
 * Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
 * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may be subject to their corresponding license terms.
@@ -510,7 +510,7 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
 
     if (FunctionEntryNode)
     {
-        const int32 NetMask = FUNC_Net | FUNC_NetMulticast | FUNC_NetServer | FUNC_NetClient;
+        const int32 NetMask = FUNC_Net | FUNC_NetMulticast | FUNC_NetServer | FUNC_NetClient | FUNC_NetReliable;
         int32 NetFlags = InFlags & NetMask;
         NetFlags = NetFlags ? FUNC_Net | NetFlags : 0;
 

--- a/unreal/Puerts/Typing/ue/puerts.d.ts
+++ b/unreal/Puerts/Typing/ue/puerts.d.ts
@@ -155,6 +155,7 @@ declare module "ue" {
     namespace rpc {
         export enum FunctionFlags {
             FUNC_Net				= 0x00000040,   // Function is network-replicated.
+            FUNC_NetReliable		= 0x00000080,   // Function should be sent reliably on the network.
             FUNC_NetMulticast		= 0x00004000,	// Function is networked multicast Server -> All Clients
             FUNC_NetServer			= 0x00200000,	// Function is executed on servers (set by replication code if passes check)
             FUNC_NetClient			= 0x01000000,	// function is executed on clients


### PR DESCRIPTION
# 简述
扩展现有的rpc flags，补充了对reliable rpc的支持。
已经过测试。
# 测试方法

* 设置90%丢包率，在控制台输入：net.pktloss=90
* 分别测试添加及未添加 `rpc.FunctionFlags.FUNC_NetReliable` 标记的RPC函数，检查其是否存在因丢包而导致的未执行。