### PR TITLE
[unreal]修正蓝图CDO构造时, 会导致v8 API暴露在多线程环境下的问题. fix #354

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -1420,12 +1420,16 @@ void FJsEnvImpl::OnAsyncLoadingFlushUpdate()
             if (PendingConstructObjects[i].IsValid())
             {
                 auto PendingObject = PendingConstructObjects[i].Get();
-                auto Class = PendingObject->GetClass();
-                if (!Class->HasAnyFlags(RF_NeedPostLoad)
-                    && !Class->HasAnyInternalFlags(EInternalObjectFlags::AsyncLoading))
+                if (!PendingObject->HasAnyFlags(RF_NeedPostLoad)
+                    && !PendingObject->HasAnyInternalFlags(EInternalObjectFlags::AsyncLoading))
                 {
-                    ReadiedObjects.Add(PendingObject);
-                    PendingConstructObjects.RemoveAt(i);
+                    auto Class = PendingObject->GetClass();
+                    if (!Class->HasAnyFlags(RF_NeedPostLoad)
+                        && !Class->HasAnyInternalFlags(EInternalObjectFlags::AsyncLoading))
+                    {
+                        ReadiedObjects.Add(PendingObject);
+                        PendingConstructObjects.RemoveAt(i);
+                    }
                 }
             }
         }

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Tencent is pleased to support the open source community by making Puerts available.
 * Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
 * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may be subject to their corresponding license terms.
@@ -316,11 +316,15 @@ FJsEnvImpl::FJsEnvImpl(std::shared_ptr<IJSModuleLoader> InModuleLoader, std::sha
     DelegateProxysCheckerHandler = FTicker::GetCoreTicker().AddTicker(TBaseDelegate<bool, float>::CreateRaw(this, &FJsEnvImpl::CheckDelegateProxys), 1);
 
     ManualReleaseCallbackMap.Reset(Isolate, v8::Map::New(Isolate));
+
+    AsyncLoadingFlushUpdateHandle = FCoreDelegates::OnAsyncLoadingFlushUpdate.AddRaw(this, &FJsEnvImpl::OnAsyncLoadingFlushUpdate);
 }
 
 // #lizard forgives
 FJsEnvImpl::~FJsEnvImpl()
 {
+    FCoreDelegates::OnAsyncLoadingFlushUpdate.Remove(AsyncLoadingFlushUpdateHandle);
+
     for(int i = 0; i < ManualReleaseCallbackList.size(); i++)
     {
         if (ManualReleaseCallbackList[i].IsValid())
@@ -1199,6 +1203,26 @@ void FJsEnvImpl::Construct(UClass* Class, UObject* Object, const v8::UniquePersi
 
 void FJsEnvImpl::TsConstruct(UTypeScriptGeneratedClass* Class, UObject* Object)
 {
+    //蓝图类的CDO会在后台线程构造, 需要将其延迟到主线程执行
+    if (!IsInGameThread())
+    {
+        if (Object->HasAnyFlags(RF_ClassDefaultObject | RF_ArchetypeObject))
+        {
+            FScopeLock Lock(&PendingConstructLock);
+            PendingConstructObjects.Add(Object);
+        }
+        else
+        {
+            Logger->Error(FString::Printf(TEXT("Construct TypeScript Object %s(%p) on illegal thread!"), *Object->GetName(), (void*)Object));
+        }
+        return;
+    }
+    
+    if (BindInfoMap.find(Class) == BindInfoMap.end())
+    {
+        MakeSureInject(Class, true, false);
+    }
+
     auto Iter = BindInfoMap.find(Class);
     if (Iter != BindInfoMap.end())
     {
@@ -1358,7 +1382,46 @@ void FJsEnvImpl::InvokeTsMethod(UObject *ContextObject, UFunction *Function, FFr
 
 void FJsEnvImpl::NotifyReBind(UTypeScriptGeneratedClass* Class)
 {
-    MakeSureInject(Class, true, false);
+    if (IsInGameThread())
+    {
+        MakeSureInject(Class, true, false);
+    }
+    else
+    {
+        //蓝图类加载时会在后台线程Bind, 此时只接管其ClassConstructor即可, 在其初次构造时再Inject
+        Class->ClassConstructor = &UTypeScriptGeneratedClass::StaticConstructor;
+    }
+}
+
+void FJsEnvImpl::OnAsyncLoadingFlushUpdate()
+{
+    FScopeLock Lock(&PendingConstructLock);
+    for (auto& ObjectPtr : PendingConstructObjects)
+    {
+        if (!ObjectPtr.IsValid())
+        {
+            continue;
+        }
+        UObject* PendingObject = ObjectPtr.Get();
+
+        TArray<UTypeScriptGeneratedClass*> SuperClasses;
+        UClass* Class = PendingObject->GetClass();
+        while (Class != nullptr)
+        {
+            if (auto TypeScriptGeneratedClass = Cast<UTypeScriptGeneratedClass>(Class))
+            {
+                SuperClasses.Add(TypeScriptGeneratedClass);
+            }
+            Class = Class->GetSuperClass();
+        }
+
+        //从基类到派生类依次构造
+        for (int32 i = SuperClasses.Num()-1; i >= 0; --i)
+        {
+            TsConstruct(SuperClasses[i], PendingObject);
+        }
+    }
+    PendingConstructObjects.Empty();
 }
 
 void FJsEnvImpl::ExecuteDelegate(v8::Isolate* Isolate, v8::Local<v8::Context>& Context, const v8::FunctionCallbackInfo<v8::Value>& Info, void *DelegatePtr)

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Tencent is pleased to support the open source community by making Puerts available.
 * Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
 * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may be subject to their corresponding license terms.
@@ -224,6 +224,8 @@ private:
     void SetInspectorCallback(const v8::FunctionCallbackInfo<v8::Value> &Info);
 
     void DispatchProtocolMessage(const v8::FunctionCallbackInfo<v8::Value> &Info);
+
+    void OnAsyncLoadingFlushUpdate();
 
     struct ObjectMerger;
 
@@ -462,6 +464,13 @@ private:
     v8::Global<v8::Map> ManualReleaseCallbackMap;
 
     std::vector<TWeakObjectPtr<UDynamicDelegateProxy>> ManualReleaseCallbackList;
+
+    FCriticalSection PendingConstructLock;
+    
+    TSet<TWeakObjectPtr<UObject>> PendingConstructObjects;
+    
+    FDelegateHandle AsyncLoadingFlushUpdateHandle;
+
 };
 
 }

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -469,7 +469,7 @@ private:
 
     FCriticalSection PendingConstructLock;
     
-    TSet<TWeakObjectPtr<UObject>> PendingConstructObjects;
+    TArray<TWeakObjectPtr<UObject>> PendingConstructObjects;
     
     FDelegateHandle AsyncLoadingFlushUpdateHandle;
 

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -227,6 +227,8 @@ private:
 
     void OnAsyncLoadingFlushUpdate();
 
+    void ConstructPendingObject(UObject* PendingObject);
+
     struct ObjectMerger;
 
     std::unique_ptr<ObjectMerger>& GetObjectMerger(UStruct * Struct);


### PR DESCRIPTION
补充信息：
1. 只有蓝图类的CDO会在后台线程加载时构造，其它对象都是在GameThread中构造的。
2. 现将这类TS蓝图CDO，在后台线程发生构造时放入Pending列表，在加载完毕回到主线程后再构造。（延迟构造）
3. 构造时（TsConstruct），如果发现TS类型尚未进行Inject，会补充Inject。（应该只发生在TS蓝图CDO的构造中）