### PR TITLE
add base class function signature into ue.d.ts

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -636,9 +636,9 @@ void FTypeScriptDeclarationGenerator::GatherExtensions(UStruct *Struct, FStringB
     }
 }
 
-void FTypeScriptDeclarationGenerator::GenResolvedFunctions(UClass* InClass, FStringBuffer& Buff)
+void FTypeScriptDeclarationGenerator::GenResolvedFunctions(UStruct *Struct, FStringBuffer& Buff)
 {
-    FunctionOutputs& Outputs = GetFunctionOutputs(InClass);
+    FunctionOutputs& Outputs = GetFunctionOutputs(Struct);
     for(FunctionOutputs::iterator Iter = Outputs.begin(); Iter != Outputs.end(); ++Iter)
     {
         FunctionOverloads& Overloads = Iter->second;
@@ -648,10 +648,10 @@ void FTypeScriptDeclarationGenerator::GenResolvedFunctions(UClass* InClass, FStr
         }
 
         const FunctionKey& FunctionKey = Iter->first;
-        UClass* SuperClass = InClass->GetSuperClass();
-        while(SuperClass != nullptr)
+        UStruct* SuperStruct = Struct->GetSuperStruct();
+        while(SuperStruct != nullptr)
         {
-            FunctionOutputs& SuperOutputs = GetFunctionOutputs(SuperClass);
+            FunctionOutputs& SuperOutputs = GetFunctionOutputs(SuperStruct);
             FunctionOutputs::iterator SuperOutputsIter = SuperOutputs.find(FunctionKey);
             if (SuperOutputsIter != SuperOutputs.end())
             {
@@ -667,7 +667,7 @@ void FTypeScriptDeclarationGenerator::GenResolvedFunctions(UClass* InClass, FStr
                     }
                 }
             }
-            SuperClass = SuperClass->GetSuperClass();
+            SuperStruct = SuperStruct->GetSuperStruct();
         }
     }
 }
@@ -833,6 +833,8 @@ void FTypeScriptDeclarationGenerator::GenStruct(UStruct *Struct)
     }
 
     GatherExtensions(Struct, StringBuffer);
+    
+    GenResolvedFunctions(Struct, StringBuffer);
 
     StringBuffer << "    static StaticClass(): Class;\n";
     

--- a/unreal/Puerts/Source/DeclarationGenerator/Public/TypeScriptDeclarationGenerator.h
+++ b/unreal/Puerts/Source/DeclarationGenerator/Public/TypeScriptDeclarationGenerator.h
@@ -74,7 +74,7 @@ struct DECLARATIONGENERATOR_API FTypeScriptDeclarationGenerator
 
     void GatherExtensions(UStruct *Struct, FStringBuffer& Buff);
 
-    void GenResolvedFunctions(UClass* InClass, FStringBuffer& Buff);
+    void GenResolvedFunctions(UStruct *Struct, FStringBuffer& Buff);
 
     FunctionOutputs& GetFunctionOutputs(UStruct *Struct);
 


### PR DESCRIPTION
add base class function signature into ue.d.ts if the sub class has a different one. Warning: this signature is only used for tsc pass through and won't work properly thus it will be marked as deprecated