### PR TITLE
add base class function signature into ue.d.ts if the sub class has a different one

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Public/TypeScriptDeclarationGenerator.h
+++ b/unreal/Puerts/Source/DeclarationGenerator/Public/TypeScriptDeclarationGenerator.h
@@ -11,6 +11,8 @@
 #include "CoreUObject.h"
 #include <map>
 #include <vector>
+
+#include "JSClassRegister.h"
 #include "PropertyMacros.h"
 
 struct DECLARATIONGENERATOR_API FStringBuffer
@@ -37,6 +39,24 @@ struct DECLARATIONGENERATOR_API FTypeScriptDeclarationGenerator
     TSet<UObject*> Processed;
     TSet<FString> ProcessedByName;
     std::map<UStruct*, std::vector<UFunction*>> ExtensionMethodsMap;
+    struct FunctionKey
+    {
+        FunctionKey(const FString& InFunctioName, bool InIsStatic)
+            : FunctionName(InFunctioName)
+            , IsStatic(InIsStatic)
+        {}
+
+        bool operator < (const FunctionKey& other) const
+        {
+            return IsStatic != other.IsStatic ? IsStatic < other.IsStatic : FunctionName < other.FunctionName;
+        }
+        
+        FString FunctionName;
+        bool IsStatic;
+    };
+    typedef TArray<FString> FunctionOverloads;
+    typedef std::map<FunctionKey, FunctionOverloads> FunctionOutputs;
+    std::map<UStruct*, FunctionOutputs> AllFuncionOutputs;
 
     void InitExtensionMethodsMap();
 
@@ -50,8 +70,18 @@ struct DECLARATIONGENERATOR_API FTypeScriptDeclarationGenerator
     
     virtual bool GenFunction(FStringBuffer& OwnerBuffer,UFunction* Function, bool WithName = true, bool ForceOneway = false, bool IgnoreOut = false, bool IsExtensionMethod = false);
 
-    void GenExtensions(UStruct *Struct, FStringBuffer& Buff);
-    
+    virtual bool GenTemplateBindingFunction(FStringBuffer& OwnerBuffer, puerts::NamedFunctionInfo* Func, bool IsStatic);
+
+    void GatherExtensions(UStruct *Struct, FStringBuffer& Buff);
+
+    void GenResolvedFunctions(UStruct *Struct, FStringBuffer& Buff);
+
+    FunctionOutputs& GetFunctionOutputs(UStruct *Struct);
+
+    FunctionOverloads& GetFunctionOverloads(FunctionOutputs& Outputs, const FString& FunctionName, bool IsStatic);
+
+    void TryToAddOverload(FunctionOutputs& Outputs, const FString& FunctionName, bool IsStatic, const FString& Overload);
+
     virtual void GenClass(UClass* Class);
     
     virtual void GenEnum(UEnum *Enum);


### PR DESCRIPTION
Warning: this signature is only used for tsc pass through and won't work properly thus it will be marked as deprecated.