### PR TITLE
修复GetStringFromNative在win平台潜在的编码转换bug并使用unsafe优化不必要的gc。

### DIFF
--- a/unity/Assets/Puerts/Src/PuertsDLL.cs
+++ b/unity/Assets/Puerts/Src/PuertsDLL.cs
@@ -80,7 +80,7 @@ namespace Puerts
 
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr CreateJSEngineWithNode();
-        
+
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr CreateJSEngineWithExternalEnv(IntPtr externalRuntime, IntPtr externalContext);
 
@@ -98,26 +98,12 @@ namespace Puerts
             IntPtr fn = v8FunctionCallback == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(v8FunctionCallback);
             SetGlobalFunction(isolate, name, fn, data);
         }
-        
-        private static string GetStringFromNative(IntPtr str, int strlen)
+
+        private static unsafe string GetStringFromNative(IntPtr str, int strlen)
         {
             if (str != IntPtr.Zero)
             {
-#if PUERTS_GENERAL || (UNITY_WSA && !UNITY_EDITOR)
-                byte[] buffer = new byte[strlen];
-                Marshal.Copy(str, buffer, 0, strlen);
-                return Encoding.UTF8.GetString(buffer);
-#else
-                string ret = Marshal.PtrToStringAnsi(str, strlen);
-                if (ret == null)
-                {
-                    int len = strlen;
-                    byte[] buffer = new byte[len];
-                    Marshal.Copy(str, buffer, 0, len);
-                    return Encoding.UTF8.GetString(buffer);
-                }
-                return ret;
-#endif
+                return Encoding.UTF8.GetString((byte*)str, strlen);
             }
             else
             {
@@ -185,7 +171,7 @@ namespace Puerts
             GCHandle.Alloc(constructor);
             GCHandle.Alloc(destructor);
 #endif
-            IntPtr fn1 = constructor == null ? IntPtr.Zero: Marshal.GetFunctionPointerForDelegate(constructor);
+            IntPtr fn1 = constructor == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(constructor);
             IntPtr fn2 = destructor == null ? IntPtr.Zero : Marshal.GetFunctionPointerForDelegate(destructor);
 
             return _RegisterClass(isolate, BaseTypeId, fullName, fn1, fn2, data);


### PR DESCRIPTION
由于v8的native代码确定性地返回UTF-8编码的字符串，尽管目前Win 10平台下System.Text.Encoding.Default为UTF-8，但仍可能某些配置下为当前代码页，导致Marshal.PtrToStringAnsi产生错误的编码转换，并且就算正确发现不匹配的编码并返回了null，也产生了无谓的开销，完全可以确定性地使用 System.Text.Encoding.UTF8.Encode。