### PR TITLE
修正 StructWrapper Property 指针未清理导致 Crash 问题

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
@@ -35,7 +35,9 @@ public:
         ExternalFinalize = nullptr;
         Struct = InStruct;
         Properties.clear();
+        PropertiesMap.clear();
         Functions.clear();
+        FunctionsMap.clear();
         ExtensionMethods.clear();
     }
 
@@ -51,8 +53,6 @@ protected:
     std::vector<std::shared_ptr<FFunctionTranslator>> Functions;
 
     std::map<FString, std::shared_ptr<FFunctionTranslator>> FunctionsMap;
-
-    std::map<FString, std::shared_ptr<FFunctionTranslator>> MethodsMap;
 
     std::shared_ptr<FFunctionTranslator> GetFunctionTranslator(UFunction *InFunction);
 


### PR DESCRIPTION
修正由于原 JSGeneratedClass 释放以后，StructWrapper 还持有原 UClass Property 指针导致 C…rash 的问题。 并删除没有使用的 MethodsMap 属性