### PR TITLE
[unity]新增csharp侧ExecuteModule获取module的导出的能力。修复JSObject内存问题。添加JSObject.get

### DIFF
--- a/quickjs-build/include/quickjs-msvc.h
+++ b/quickjs-build/include/quickjs-msvc.h
@@ -1005,6 +1005,7 @@ void JS_MapClear(JSContext *ctx, JSValueConst this_val);
 JSValue JS_DupModule(JSContext *ctx, JSModuleDef* v);
 
 /*-------end fuctions for v8 api---------*/
+JSValue JS_GET_MODULE_NS(JSContext *ctx, JSModuleDef* v);
 
 #undef js_unlikely
 #undef js_force_inline

--- a/quickjs-build/quickjs/quickjs.c
+++ b/quickjs-build/quickjs/quickjs.c
@@ -54049,3 +54049,8 @@ JSValue JS_DupModule(JSContext *ctx, JSModuleDef* v)
 }
 
 /*-------end fuctions for v8 api---------*/
+
+JSValue JS_GET_MODULE_NS(JSContext *ctx, JSModuleDef* v)
+{
+    return js_get_module_ns(ctx, v);
+}

--- a/unity/Assets/Puerts/Src/GenericDelegate.cs
+++ b/unity/Assets/Puerts/Src/GenericDelegate.cs
@@ -339,6 +339,23 @@ namespace Puerts
             this.jsEnv = jsEnv;
         }
 
+        Func<JSObject, string, object> MemberGetter;
+        public T Get<T>(string key) 
+        {
+            if (MemberGetter == null) 
+            {
+                MemberGetter = jsEnv.Eval<Func<JSObject, string, object>>("(function(obj, key) { return obj[key] })");
+            }
+            object value = MemberGetter(this, key);
+            
+            Type maybeDelegateType = typeof(T);
+            if (typeof(Delegate).IsAssignableFrom(typeof(T))) {
+                return (T)(object)jsEnv.genericDelegateFactory.Create(typeof(T), (IntPtr)value);
+            }
+            
+            return (T)value;
+        }
+
         ~JSObject() 
         {
 #if THREAD_SAFE

--- a/unity/Assets/Puerts/Src/JsEnv.cs
+++ b/unity/Assets/Puerts/Src/JsEnv.cs
@@ -192,7 +192,7 @@ namespace Puerts
             return loader.ReadFile(identifer, out debugPath);
         }
 
-        public void ExecuteModule(string filename)
+        public JSObject ExecuteModule(string filename)
         {
             if (loader.FileExists(filename))
             {
@@ -202,14 +202,10 @@ namespace Puerts
                     string exceptionInfo = PuertsDLL.GetLastExceptionInfo(isolate);
                     throw new Exception(exceptionInfo);
                 }
+                JSObject result = StaticTranslate<JSObject>.Get(Idx, isolate, NativeValueApi.GetValueFromResult, resultInfo, false);
                 PuertsDLL.ResetResult(resultInfo);
-                // string debugPath;
-                // var context = loader.ReadFile(filename, out debugPath);
-                // if (context == null)
-                // {
-                //     throw new InvalidProgramException("can not find " + filename);
-                // }
-                // Eval(context, debugPath);
+                
+                return result;
             }
             else
             {

--- a/unity/Assets/Puerts/Src/JsEnv.cs
+++ b/unity/Assets/Puerts/Src/JsEnv.cs
@@ -196,6 +196,9 @@ namespace Puerts
         {
             if (loader.FileExists(filename))
             {
+#if THREAD_SAFE
+            lock(this) {
+#endif
                 IntPtr resultInfo = PuertsDLL.ExecuteModule(isolate, filename);
                 if (resultInfo == IntPtr.Zero)
                 {
@@ -204,7 +207,9 @@ namespace Puerts
                 }
                 JSObject result = StaticTranslate<JSObject>.Get(Idx, isolate, NativeValueApi.GetValueFromResult, resultInfo, false);
                 PuertsDLL.ResetResult(resultInfo);
-                
+#if THREAD_SAFE
+            }
+#endif
                 return result;
             }
             else

--- a/unity/general/Src/UnitTest/UnitTest.cs
+++ b/unity/general/Src/UnitTest/UnitTest.cs
@@ -1181,7 +1181,7 @@ namespace Puerts.UnitTest
             var loader = new TxtLoader();
             loader.AddMockFileContent("whatever.mjs", @"
                 import csharp from 'csharp';
-                const func = function() { return csharp.System.String.Join('hello', ' world') }
+                const func = function() { return csharp.System.String.Join(' ', 'hello', 'world') }
                 export { func };
             ");
             var jsEnv = new JsEnv(loader);

--- a/unity/general/Src/UnitTest/UnitTest.cs
+++ b/unity/general/Src/UnitTest/UnitTest.cs
@@ -1179,16 +1179,17 @@ namespace Puerts.UnitTest
         public void ESModuleImportCSharp()
         {
             var loader = new TxtLoader();
-            loader.AddMockFileContent("whatever.mjs", @"import csharp from 'csharp'; csharp.System.Console.WriteLine('ESModuleImportCSharp')");
+            loader.AddMockFileContent("whatever.mjs", @"
+                import csharp from 'csharp';
+                const func = function() { return csharp.System.String.Join('hello', ' world') }
+                export { func };
+            ");
             var jsEnv = new JsEnv(loader);
-            try
-            {
-                jsEnv.ExecuteModule("whatever.mjs");
-            }
-            catch (Exception e)
-            {
-                Assert.True(false);
-            }
+            JSObject obj = jsEnv.ExecuteModule("whatever.mjs");
+
+            Func<string> func = obj.Get<Func<string>>("func");
+            Assert.True(func == "hello world");
+
             jsEnv.Dispose();
         }
     }

--- a/unity/general/Src/UnitTest/UnitTest.cs
+++ b/unity/general/Src/UnitTest/UnitTest.cs
@@ -1188,7 +1188,7 @@ namespace Puerts.UnitTest
             JSObject obj = jsEnv.ExecuteModule("whatever.mjs");
 
             Func<string> func = obj.Get<Func<string>>("func");
-            Assert.True(func == "hello world");
+            Assert.True(func() == "hello world");
 
             jsEnv.Dispose();
         }

--- a/unity/native_src/Src/JSEngine.cpp
+++ b/unity/native_src/Src/JSEngine.cpp
@@ -255,6 +255,13 @@ namespace puerts
                 delete *Iter;
             }
         }
+        {
+            std::lock_guard<std::mutex> guard(JSObjectsMutex);
+            for (auto Iter = JSObjectMap.begin(); Iter != JSObjectMap.end(); ++Iter)
+            {
+                delete Iter->second;
+            }
+        }
         
 #if WITH_NODEJS
         // node::EmitExit(NodeEnv);

--- a/unity/native_src/Src/JSEngine_Eval.cpp
+++ b/unity/native_src/Src/JSEngine_Eval.cpp
@@ -89,7 +89,7 @@ namespace puerts {
         }
 
         const char* Code;
-        if (name_std.substr(name_length - 4, name_length).compare(".mjs") == 0) 
+        if (name_length > 4 && name_std.substr(name_length - 4, name_length).compare(".mjs") == 0) 
         {
             Code = JsEngine->ModuleResolver(name_std.c_str(), JsEngine->Idx);
             if (Code == nullptr) 
@@ -167,9 +167,7 @@ namespace puerts {
         }
         else
         {
-            // do not return the namespace by now, because quickjs doesnot support that
-            // ResultInfo.Result.Reset(Isolate, ModuleChecked->GetModuleNamespace());
-            // ResultInfo.Result.Reset(Isolate, ModuleChecked->GetModuleNamespace());
+            ResultInfo.Result.Reset(Isolate, ModuleChecked->GetModuleNamespace());
         }
         return true;
 #else
@@ -193,9 +191,9 @@ namespace puerts {
             return false;
 
         } else {
-            // val = MainIsolate->Alloc<v8::Value>();
-            // val->value_ = JS_UNDEFINED;
-            // ResultInfo.Result.Reset(MainIsolate, v8::Local<v8::Value>(val));
+            val = MainIsolate->Alloc<v8::Value>();
+            val->value_ = JS_GET_MODULE_NS(ctx, EntryModule);
+            ResultInfo.Result.Reset(MainIsolate, v8::Local<v8::Value>(val));
             return true;
             
         }

--- a/unity/native_src/Src/JSEngine_Eval.cpp
+++ b/unity/native_src/Src/JSEngine_Eval.cpp
@@ -186,6 +186,7 @@ namespace puerts {
 
         v8::Value* val = nullptr;
         if (JS_IsException(evalRet)) {
+            JS_FreeValue(ctx, evalRet);
             MainIsolate->handleException();
             LastExceptionInfo = FV8Utils::ExceptionToString(Isolate, TryCatch);
             return false;
@@ -193,6 +194,8 @@ namespace puerts {
         } else {
             val = MainIsolate->Alloc<v8::Value>();
             val->value_ = JS_GET_MODULE_NS(ctx, EntryModule);
+            JS_FreeValue(ctx, evalRet);
+            // JS_FreeValue(ctx, val->value_);
             ResultInfo.Result.Reset(MainIsolate, v8::Local<v8::Value>(val));
             return true;
             


### PR DESCRIPTION
`JSObject.Get`功能受 #610 启发