### PR TITLE
PuerTS 支持 Cooked 版本包外文件，编辑器模式和Shipping编译时无效

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/DefaultJSModuleLoader.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/DefaultJSModuleLoader.cpp
@@ -60,8 +60,8 @@ bool DefaultJSModuleLoader::CheckExists(const FString& PathIn, FString& Path, FS
         UE_LOG(LogTemp, Display, TEXT("Found external file: %s from %s"), *AbsolutePath, *PathIn);
         Path = NormalizedPath;
         return true;
-    } 
-#endif // !UE_BUILD_SHIPPING
+    }
+#endif    // !WITH_EDITOR && !UE_BUILD_SHIPPING
 
     if (PlatformFile.FileExists(*NormalizedPath))
     {

--- a/unreal/Puerts/Source/JsEnv/Private/DefaultJSModuleLoader.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/DefaultJSModuleLoader.cpp
@@ -57,7 +57,7 @@ bool DefaultJSModuleLoader::CheckExists(const FString& PathIn, FString& Path, FS
     if (PlatformPhysical.FileExists(*NormalizedPath))
     {
         AbsolutePath = PlatformPhysical.ConvertToAbsolutePathForExternalAppForRead(*NormalizedPath);
-        UE_LOG(LogTemp, Display, TEXT("Found external file: %s from %s"), *AbsolutePath, *PathIn);
+        UE_LOG(Puerts, Display, TEXT("Found external file: %s from %s"), *AbsolutePath, *PathIn);
         Path = NormalizedPath;
         return true;
     }

--- a/unreal/Puerts/Source/JsEnv/Private/DefaultJSModuleLoader.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/DefaultJSModuleLoader.cpp
@@ -50,6 +50,19 @@ bool DefaultJSModuleLoader::CheckExists(const FString& PathIn, FString& Path, FS
 {
     IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
     FString NormalizedPath = PathNormalize(PathIn);
+
+#if !WITH_EDITOR && !UE_BUILD_SHIPPING
+    // 优先处理本地目录中的额外文件，在 Shipping 和 编辑器模式下无效
+    IPlatformFile& PlatformPhysical = IPlatformFile::GetPlatformPhysical();
+    if (PlatformPhysical.FileExists(*NormalizedPath))
+    {
+        AbsolutePath = PlatformPhysical.ConvertToAbsolutePathForExternalAppForRead(*NormalizedPath);
+        UE_LOG(LogTemp, Display, TEXT("Found external file: %s from %s"), *AbsolutePath, *PathIn);
+        Path = NormalizedPath;
+        return true;
+    } 
+#endif // !UE_BUILD_SHIPPING
+
     if (PlatformFile.FileExists(*NormalizedPath))
     {
         AbsolutePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*NormalizedPath);


### PR DESCRIPTION
在打包版本上进行迭代调试开发时，进行少量JS文件修改替换的方案。为了项目安全性考虑，此方案在编辑器模式和Shipping编译时无效。

具体使用方法：
打包后，将修改过的 JS 文件（注意一定是JS文件而不是TS文件），按照原目录结构，复制到设备如下位置，重新启动游戏即可。若文件加载成功，会在Log中看到类似 “Found external file” 的内容。
1. Android 包外JS根目录（非Distribution构建）：<设备存储>/UE4Game/<项目名>/<项目名>/Content/JavaScript
2. Android 包外JS根目录（Distribution构建）：<设备存储>/Android/data/<项目bundleid>/files/UE4Game/<项目名>/<项目名>/Content/JavaScript
3. iOS 包外JS根目录：<App文件目录>/Documents/<项目名>/Content/JavaScript
4. Windows JS根目录：<打包目录>/<项目名>/Content/JavaScript