### PR TITLE
add console.trace function

### DIFF
--- a/unity/Assets/Puerts/Src/Resources/puerts/log.mjs
+++ b/unity/Assets/Puerts/Src/Resources/puerts/log.mjs
@@ -43,6 +43,14 @@ if (UnityEngine_Debug) {
         UnityEngine_Debug.LogError(toString(arguments));
     }
     
+    console.trace = function() {
+        if (console_org) console_org.trace.apply(null, Array.prototype.slice.call(arguments));
+        let stack = new Error().stack; // get js stack
+        stack = stack.substring(stack.indexOf("\n")+1); // remove first line ("Error")
+        stack = stack.replace(/^ {4}/gm, ""); // remove indentation
+        UnityEngine_Debug.Log(toString(arguments) + "\n" + stack + "\n");
+    }
+    
     global.console = console;
     puerts.console = console;
 }


### PR DESCRIPTION
Adding console.trace support to Unity puerts logging.

This PR adds the stacktrace to Unity log output when calling ``console.trace`` from js

Example:
![image](https://user-images.githubusercontent.com/5083203/155840113-b3124cf1-01ed-4497-b2d5-3d43053d8e55.png)
