### PR TITLE
[Unreal]容器增加GetRef接口，用于显式获取容器内元素引用

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/ContainerWrapper.h
+++ b/unreal/Puerts/Source/JsEnv/Private/ContainerWrapper.h
@@ -295,9 +295,14 @@ private:
     static void Add(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     // 参数：索引
-    // 返回：元素
+    // 返回：元素（值类型，有内存拷贝）
     // 作用：获取索引对应的元素，如果索引越界则抛出异常
     static void Get(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+    // 参数：索引
+    // 返回：元素（引用类型）
+    // 作用：获取索引对应的元素，如果索引越界则抛出异常
+    static void GetRef(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     // 参数1：索引；参数2：元素
     // 返回：无
@@ -329,7 +334,6 @@ private:
     // 作用：清空容器
     static void Empty(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
-private:
     FORCEINLINE static int32 AddUninitialized(FScriptArray* ScriptArray, int32 ElementSize, int32 Count = 1);
 
     FORCEINLINE static uint8* GetData(FScriptArray* ScriptArray, int32 ElementSize, int32 Index);
@@ -337,6 +341,8 @@ private:
     FORCEINLINE static void Construct(FScriptArray* ScriptArray, FPropertyTranslator* Inner, int32 Index, int32 Count = 1);
 
     static int32 FindIndexInner(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+    FORCEINLINE static void InternalGet(const v8::FunctionCallbackInfo<v8::Value>& Info, bool PassByPointer);
 };
 
 class FScriptSetWrapper : public FContainerWrapper<FScriptSet>
@@ -348,6 +354,8 @@ private:
     static void Add(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     static void Get(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+    static void GetRef(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     static void Contains(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
@@ -361,8 +369,9 @@ private:
 
     static void Empty(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
-private:
     FORCEINLINE static int32 FindIndexInner(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+    FORCEINLINE static void InternalGet(const v8::FunctionCallbackInfo<v8::Value>& Info, bool PassByPointer);
 };
 
 class FScriptMapWrapper : public FContainerWrapper<FScriptMap>
@@ -374,6 +383,8 @@ private:
     static void Add(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     static void Get(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+    static void GetRef(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     static void Set(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
@@ -387,8 +398,9 @@ private:
 
     static void Empty(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
-private:
     FORCEINLINE static FScriptMapLayout GetScriptLayout(const PropertyMacro* KeyProperty, const PropertyMacro* ValueProperty);
+
+    FORCEINLINE static void InternalGet(const v8::FunctionCallbackInfo<v8::Value>& Info, bool PassByPointer);
 };
 
 class FFixSizeArrayWrapper
@@ -405,6 +417,10 @@ private:
 
     static void Get(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
+    static void GetRef(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
     static void Set(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+    FORCEINLINE static void InternalGet(const v8::FunctionCallbackInfo<v8::Value>& Info, bool PassByPointer);
 };
 }    // namespace puerts

--- a/unreal/Puerts/Typing/ue/puerts.d.ts
+++ b/unreal/Puerts/Typing/ue/puerts.d.ts
@@ -29,6 +29,7 @@ declare module "ue" {
     interface FixSizeArray<T> {
         Num(): number;
         Get(Index: number): T;
+        GetRef(Index: number): T;
         Set(Index: number, Value: T): void;
     }
     
@@ -36,6 +37,7 @@ declare module "ue" {
         Num(): number;
         Add(Value: T): void;
         Get(Index: number): T;
+        GetRef(Index: number): T;
         Set(Index: number, Value: T): void;
         Contains(Value: T): boolean;
         FindIndex(Value: T): number;
@@ -48,6 +50,7 @@ declare module "ue" {
         Num(): number;
         Add(Value: T): void;
         Get(Index: number): T;  // TODO - 这个接口要用Index吗？
+        GetRef(Index: number): T;
         // Set(Index: number, Value: T): void;
         Contains(Value: T): boolean;
         FindIndex(Value: T): number;
@@ -61,6 +64,7 @@ declare module "ue" {
         Num(): number;
         Add(Key: TKey, Value: TValue): void;
         Get(Key: TKey): TValue | undefined;
+        GetRef(Key: TKey): TValue | undefined;
         Set(Key: TKey, Value: TValue): void;    // 即Add()。TODO - 有存在的必要吗？
         Remove(Key: TKey): void;
         GetMaxIndex(): number;                  // TODO - 接口注释要说明返回的是kv的索引。只有调用了Empty后才会返回0


### PR DESCRIPTION
#703 #604 
`ContainerWrapper.h`去掉的private是为了解决clang格式化检查