### PR TITLE
最新的 tsc 编译不过去

### DIFF
--- a/unity/Assets/Puerts/Editor/Resources/puerts/templates/dts.tpl.cjs
+++ b/unity/Assets/Puerts/Editor/Resources/puerts/templates/dts.tpl.cjs
@@ -49,8 +49,7 @@ module.exports = function TypingTemplate(data, esmMode) {
 if (!esmMode) {
     tt`   
 declare module 'csharp' {
-    import * as CSharp from 'csharp';
-    export default CSharp;
+    export * as CSharp from 'csharp'
 }
     `
 }


### PR DESCRIPTION
```bash
tsc --version
Version 4.6.3
```
会报这个错误：
```bash
index.d.ts:4:5 - error TS2303: Circular definition of import alias 'CSharp'.
```