### PR TITLE
Revert "抛异常的时候，会重复打印一部分内容"

### DIFF
--- a/unity/native_src/Inc/V8Utils.h
+++ b/unity/native_src/Inc/V8Utils.h
@@ -80,23 +80,21 @@ public:
         {
             v8::Local<v8::Context> Context(Isolate->GetCurrentContext());
 
+            // 输出 (filename):(line number): (message).
             std::ostringstream stm;
+            v8::String::Utf8Value FileName(Isolate, Message->GetScriptResourceName());
+            int LineNum = Message->GetLineNumber(Context).FromJust();
+            const char * StrFileName = *FileName;
+            stm << (StrFileName == nullptr ? "unknow file" : StrFileName) << ":" << LineNum << ": " << ExceptionStr;
+
+            stm << std::endl;
 
             // 输出调用栈信息
             v8::Local<v8::Value> StackTrace;
             if (TryCatch.StackTrace(Context).ToLocal(&StackTrace))
             {
                 v8::String::Utf8Value StackTraceVal(Isolate, StackTrace);
-                stm << *StackTraceVal;
-            }
-            else 
-            {
-                // 输出 (filename):(line number): (message).
-                v8::String::Utf8Value FileName(Isolate, Message->GetScriptResourceName());
-                int LineNum = Message->GetLineNumber(Context).FromJust();
-                const char * StrFileName = *FileName;
-                stm << (StrFileName == nullptr ? "unknow file" : StrFileName) << ":" << LineNum << ": " << ExceptionStr;
-                stm << std::endl;
+                stm << std::endl << *StackTraceVal;
             }
             return stm.str();
         }


### PR DESCRIPTION
quickjs版本的stack中没有message信息，这个改动 #682  后message就没有了。需要兼容。