### PR TITLE
Fix每一帧的GC问题

### DIFF
--- a/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
+++ b/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
@@ -636,7 +636,7 @@ namespace Puerts
 #endif
             }
             PuertsDLL.LogicTick(isolate);
-            tickHandler.ForEach(fn =>
+            foreach (var fn in tickHandler)
             {
                 IntPtr resultInfo = GenericDelegate.InvokeJSFunction(
                     this, fn, 0, false, 
@@ -647,8 +647,7 @@ namespace Puerts
                     var exceptionInfo = PuertsDLL.GetFunctionLastExceptionInfo(fn);
                     throw new Exception(exceptionInfo);
                 }
-
-            });
+            }
 #if THREAD_SAFE
             }
 #endif


### PR DESCRIPTION
如下图，可以看到JsEnv.Tick每帧都会有个GC Alloc，通过此优化可避免该GC Alloc。

<img width="803" alt="企业微信截图_16524063877979" src="https://user-images.githubusercontent.com/4433100/168523126-af7d192d-6d45-4ea7-a143-7dcec55b14ab.png">
<img width="691" alt="企业微信截图_16524064584531" src="https://user-images.githubusercontent.com/4433100/168523176-16d65413-ee0b-4298-afbe-1d5f45a7d18c.png">
