### PR TITLE
导出index.d.ts报错的问题

### DIFF
--- a/unity/Assets/Puerts/Editor/Src/Generator/DTS.cs
+++ b/unity/Assets/Puerts/Editor/Src/Generator/DTS.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using UnityEngine;
 
 namespace Puerts.Editor
 {
@@ -465,7 +466,14 @@ namespace Puerts.Editor
                     foreach (var t in refTypes.Distinct())
                     {
                         var info = TsTypeGenInfo.FromType(t, genTypeSet);
-                        tsTypeGenInfos.Add(info.FullName, info);
+                        try 
+                        {
+                            tsTypeGenInfos.Add(info.FullName, info);                     
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogError($"Add {info.FullName} failed!\n{e.ToString()}");
+                        }
                     }
                     foreach (var info in tsTypeGenInfos)
                     {

--- a/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
+++ b/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
@@ -636,7 +636,7 @@ namespace Puerts
 #endif
             }
             PuertsDLL.LogicTick(isolate);
-            tickHandler.ForEach(fn =>
+            foreach (var fn in tickHandler)
             {
                 IntPtr resultInfo = GenericDelegate.InvokeJSFunction(
                     this, fn, 0, false, 
@@ -647,8 +647,7 @@ namespace Puerts
                     var exceptionInfo = PuertsDLL.GetFunctionLastExceptionInfo(fn);
                     throw new Exception(exceptionInfo);
                 }
-
-            });
+            }
 #if THREAD_SAFE
             }
 #endif


### PR DESCRIPTION
业务侧不同的程序集里可能有重名的类，增加日志以直接暴露有重名的类