### PR TITLE
修改vscode第二次调试无法启动:Update JsEnv.cs

### DIFF
--- a/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
+++ b/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
@@ -739,6 +739,13 @@ namespace Puerts
             lock (jsEnvs)
             {
                 if (disposed) return;
+                #region // 解决调试中打开预制体后, 下次无法调试
+
+                if (this.debugPort != -1) {
+                    PuertsDLL.DestroyInspector(isolate);
+                }
+
+                #endregion
                 jsEnvs[Idx] = null;
                 PuertsDLL.DestroyJSEngine(isolate);
                 isolate = IntPtr.Zero;

--- a/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
+++ b/unity/Assets/Puerts/Runtime/Src/JsEnv.cs
@@ -739,13 +739,15 @@ namespace Puerts
             lock (jsEnvs)
             {
                 if (disposed) return;
+#if UNITY_EDITOR
                 #region // 解决调试中打开预制体后, 下次无法调试
 
                 if (this.debugPort != -1) {
                     PuertsDLL.DestroyInspector(isolate);
                 }
-
+    
                 #endregion
+#endif                  
                 jsEnvs[Idx] = null;
                 PuertsDLL.DestroyJSEngine(isolate);
                 isolate = IntPtr.Zero;


### PR DESCRIPTION
解决调试中打开预制体后, 下次无法调试
bug重现步骤:
打开unity打开场景, 运行游戏,调试vscode, 再打开其他预制体,代码逻辑会创建新的JeEnv的对象,关闭游戏
再运行游戏, 调试vscode时出现调试不了 
原因:
jeEnv的相应的调试没有关闭掉导致