### PR TITLE
[unity] dts generate生成受保护的属性, 以保证类型不兼容性

### DIFF
--- a/unity/Assets/Puerts/Editor/Resources/puerts/templates/dts.tpl.cjs
+++ b/unity/Assets/Puerts/Editor/Resources/puerts/templates/dts.tpl.cjs
@@ -49,6 +49,9 @@ module.exports = function TypingTemplate(data, esmMode) {
 
     tt`
 declare module 'csharp' {
+    //keep type incompatibility / 此属性保持类型不兼容
+    const __keep_incompatibility: unique symbol;
+
     namespace CSharp {
         interface $Ref<T> {
             value: T
@@ -108,7 +111,7 @@ declare module 'csharp' {
                     //keep type incompatibility / 此属性保持类型不兼容
                     if (!type.IsInterface) {
                         t`
-                        protected __keep_incompatibility: never;
+                        protected [__keep_incompatibility]: never;
                         `
                     }
                     

--- a/unity/Assets/Puerts/Editor/Resources/puerts/templates/dts.tpl.cjs
+++ b/unity/Assets/Puerts/Editor/Resources/puerts/templates/dts.tpl.cjs
@@ -104,6 +104,13 @@ declare module 'csharp' {
                     t`{
                     `;
                     t.indent = 16;
+
+                    //keep type incompatibility / 此属性保持类型不兼容
+                    if (!type.IsInterface) {
+                        t`
+                        protected __keep_incompatibility: never;
+                        `
+                    }
                     
                     // properties start
                     distinctByName(type.Properties).forEach(property=> {


### PR DESCRIPTION
参考文档: [typescript-类型兼容性](https://www.tslang.cn/docs/handbook/type-compatibility.html)

实际效果:
![image](https://user-images.githubusercontent.com/45587825/176367063-3dd17281-7d72-4403-8d44-b5ba9470d60d.png)