### PR TITLE
开启异步加载线程之后，报pending construct job的错误

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/TypeScriptGeneratedClass.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/TypeScriptGeneratedClass.cpp
@@ -123,7 +123,8 @@ void UTypeScriptGeneratedClass::ObjectInitialize(const FObjectInitializer& Objec
             int Index = PendingConstructJobs.Num();
 
             PendingConstructJobs.Add(FFunctionGraphTask::CreateAndDispatchWhenReady(
-                [Class, Self, Index]() {
+                [Class, Self, Index]()
+                {
                     if (Class.IsValid())
                     {
                         if (Self.IsValid())

--- a/unreal/Puerts/Source/JsEnv/Public/TypeScriptGeneratedClass.h
+++ b/unreal/Puerts/Source/JsEnv/Public/TypeScriptGeneratedClass.h
@@ -27,7 +27,8 @@ public:
 
     TSet<FName> FunctionToRedirect;
 
-    FGraphEventRef PendingConstructJob = nullptr;
+    FCriticalSection PendingConstructJobMutex;
+    TArray<FGraphEventRef> PendingConstructJobs;
 
     static void StaticConstructor(const FObjectInitializer& ObjectInitializer);
 


### PR DESCRIPTION
当开启异步加载线程，同时创建一个uclass的两个object的时候，因为此时上一个object的construct job可能还没有执行完，此时会报一个pending construct job的错误，导致第二个object的tsconstrut不执行