### PR TITLE
在UMG蓝图编辑界面直接挂接TypeScript脚本

### DIFF
--- a/TSWidgetPrivate.h
+++ b/TSWidgetPrivate.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Tickable.h"
+#include "TSWidgetPrivate.generated.h"
+
+UCLASS()
+class MYPROJECT_API UTSWidgetPrivate : public UObject, public FTickableGameObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintImplementableEvent)
+	void Tick(float DeltaTime);
+
+	virtual TStatId GetStatId() const;
+
+	UFUNCTION(BlueprintImplementableEvent)
+	void SetupUI(UUserWidget* ui);
+};

--- a/unreal/Puerts/Source/Puerts/Private/TSUserWidget.cpp
+++ b/unreal/Puerts/Source/Puerts/Private/TSUserWidget.cpp
@@ -1,0 +1,50 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+#include "TSUserWidget.h"
+#include "TSWidgetPrivate.h"
+
+
+UTSUserWidget::UTSUserWidget(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+	UMGTypeScript = nullptr;
+}
+
+void UTSUserWidget::NativePreConstruct()
+{
+	Super::NativePreConstruct();
+}
+
+void UTSUserWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+	CreateTSScript();
+}
+
+void UTSUserWidget::NativeDestruct()
+{
+	Super::NativeDestruct();
+}
+
+void UTSUserWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
+{
+	Super::NativeTick(MyGeometry, InDeltaTime);
+}
+
+void UTSUserWidget::CreateTSScript()
+{
+	if (TSClass)
+	{
+		UMGTypeScript = NewObject<UTSWidgetPrivate>(this, TSClass.Get());
+		UMGTypeScript->SetupUI(this);
+	}
+}
+
+void UTSUserWidget::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
+{
+	if (TSClass != nullptr)
+	{
+		UMGTypeScript = NewObject<UTSWidgetPrivate>(this, TSClass.Get());
+		UMGTypeScript->SetupUI(this);
+	}
+}
+

--- a/unreal/Puerts/Source/Puerts/Private/TSWidgetPrivate.cpp
+++ b/unreal/Puerts/Source/Puerts/Private/TSWidgetPrivate.cpp
@@ -1,0 +1,7 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+#include "TSWidgetPrivate.h"
+
+TStatId UTSWidgetPrivate::GetStatId() const
+{
+	RETURN_QUICK_DECLARE_CYCLE_STAT(USPResBuiltInActorManager, STATGROUP_Tickables);
+}

--- a/unreal/Puerts/Source/Puerts/Public/TSUserWidget.h
+++ b/unreal/Puerts/Source/Puerts/Public/TSUserWidget.h
@@ -1,0 +1,40 @@
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "TSUserWidget.generated.h"
+
+class UTSWidgetPrivate;
+
+/**
+ * BASE CLASS
+ */
+UCLASS()
+class MYPROJECT_API UTSUserWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	UTSUserWidget(const FObjectInitializer& ObjectInitializer);
+
+	UFUNCTION()
+	virtual void NativeConstruct()override;
+	virtual void NativeDestruct() override;
+	virtual void NativePreConstruct()override;
+	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+
+	void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent);
+
+private:
+	void CreateTSScript();
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	TSubclassOf<UTSWidgetPrivate> TSClass;
+
+private:
+	UPROPERTY()
+	UTSWidgetPrivate* UMGTypeScript;
+
+};

--- a/unreal/Puerts/Source/Puerts/Public/TSUserWidget.h
+++ b/unreal/Puerts/Source/Puerts/Public/TSUserWidget.h
@@ -11,7 +11,7 @@ class UTSWidgetPrivate;
  * BASE CLASS
  */
 UCLASS()
-class MYPROJECT_API UTSUserWidget : public UUserWidget
+class PUERTS_API UTSUserWidget : public UUserWidget
 {
 	GENERATED_BODY()
 

--- a/unreal/Puerts/Source/Puerts/Public/TSWidgetPrivate.h
+++ b/unreal/Puerts/Source/Puerts/Public/TSWidgetPrivate.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Tickable.h"
+#include "TSWidgetPrivate.generated.h"
+
+UCLASS()
+class MYPROJECT_API UTSWidgetPrivate : public UObject, public FTickableGameObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintImplementableEvent)
+	void Tick(float DeltaTime);
+
+	virtual TStatId GetStatId() const;
+
+	UFUNCTION(BlueprintImplementableEvent)
+	void SetupUI(UUserWidget* ui);
+};

--- a/unreal/Puerts/Source/Puerts/Public/TSWidgetPrivate.h
+++ b/unreal/Puerts/Source/Puerts/Public/TSWidgetPrivate.h
@@ -5,7 +5,7 @@
 #include "TSWidgetPrivate.generated.h"
 
 UCLASS()
-class MYPROJECT_API UTSWidgetPrivate : public UObject, public FTickableGameObject
+class PUERTS_API UTSWidgetPrivate : public UObject, public FTickableGameObject
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
在编辑器中新建蓝图类并且从UTSUserWidget 派生，，然后在TypeScript新建umg的ts业务逻辑类从UE.TSWidgetPrivate派生
即可在编辑器中旋转这个ts业务类，而直接属性umg界面的业务逻辑