### PR TITLE
pending contructor不使用wait

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Public/TypeScriptGeneratedClass.h
+++ b/unreal/Puerts/Source/JsEnv/Public/TypeScriptGeneratedClass.h
@@ -12,7 +12,15 @@
 
 #include "CoreMinimal.h"
 #include "Engine/BlueprintGeneratedClass.h"
+#include "Function.h"
+#include "SharedPointer.h"
 #include "TypeScriptGeneratedClass.generated.h"
+
+struct PendingConstructJobInfo
+{
+    TFunction<void()> Func = nullptr;
+    TSharedPtr<int> Ref = nullptr;
+};
 
 /**
  *
@@ -28,7 +36,12 @@ public:
     TSet<FName> FunctionToRedirect;
 
     FCriticalSection PendingConstructJobMutex;
-    TArray<FGraphEventRef> PendingConstructJobs;
+
+    TArray<PendingConstructJobInfo> PendingConstructInfos;
+    
+    bool IsProcessingPendingConstructJob = false;
+
+    void ProcessPendingConstructJob();
 
     static void StaticConstructor(const FObjectInitializer& ObjectInitializer);
 


### PR DESCRIPTION
1. ue不允许在postload期间调用ufunction
2. wait会导致，如果其他模块也创建了主线程的task，可能先执行其他模块的task，导致在postload期间调用ufunction