### PR TITLE
脚本创建ustruct的时候，需要init

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.cpp
@@ -436,6 +436,7 @@ void FScriptStructWrapper::New(
             else
             {
                 Memory = Alloc(static_cast<UScriptStruct*>(Struct.Get()));
+                static_cast<UScriptStruct*>(Struct.Get())->InitializeStruct(Memory);
                 const int Count = Info.Length() < Properties.size() ? Info.Length() : Properties.size();
                 for (int i = 0; i < Count; ++i)
                 {


### PR DESCRIPTION
对于非POD类型，脚本创建struct是需要init的