### PR TITLE
[unity]fix:无法访问嵌套类型中泛型

### DIFF
--- a/unity/Assets/Puerts/Runtime/Resources/puerts/csharp.mjs
+++ b/unity/Assets/Puerts/Runtime/Resources/puerts/csharp.mjs
@@ -58,7 +58,14 @@ function csTypeToClass(csType) {
         if (nestedTypes) {
             for(var i = 0; i < nestedTypes.Length; i++) {
                 let ntype = nestedTypes.get_Item(i);
-                cls[ntype.Name] = csTypeToClass(ntype);
+                if (ntype.IsGenericType) {
+                    let name = ntype.Name.split('`')[0] + '$' + ntype.GetGenericArguments().Length;
+                    let fullName = ntype.FullName.split('`')[0]/**.replace(/\+/g, '.') */ + '$' + ntype.GetGenericArguments().Length;
+                    let genericTypeInfo = cls[name] = new Map();
+                    genericTypeInfo.set('$name', fullName.replace('$', '`'));
+                } else {
+                    cls[ntype.Name] = csTypeToClass(ntype);
+                }
             }
         }
     }


### PR DESCRIPTION
如下截图, 在typescript中调用Test.Ref$1返回undefined
![image](https://user-images.githubusercontent.com/45587825/179926508-c6d6c6ca-4c55-4107-ba32-422bc92075be.png)