### PR TITLE
Fix delegate invoke crash

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.cpp
@@ -418,6 +418,11 @@ void FFunctionTranslator::CallJs(v8::Isolate* Isolate, v8::Local<v8::Context>& C
     Stack.OutParms = OldOutParms;
 }
 
+bool FFunctionTranslator::IsValid() const
+{
+    return Function.IsValid();
+}
+
 FExtensionMethodTranslator::FExtensionMethodTranslator(UFunction* InFunction) : FFunctionTranslator(InFunction, false)
 {
     TFieldIterator<PropertyMacro> It(InFunction);

--- a/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.h
+++ b/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.h
@@ -47,6 +47,8 @@ public:
     void Call(v8::Isolate* Isolate, v8::Local<v8::Context>& Context, const v8::FunctionCallbackInfo<v8::Value>& Info,
         std::function<void(void*)> OnCall);
 
+    bool IsValid() const;
+
 protected:
     FORCEINLINE void Call_ProcessParams(v8::Isolate* Isolate, v8::Local<v8::Context>& Context,
         const v8::FunctionCallbackInfo<v8::Value>& Info, void* Params, int StartPos)

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -2483,7 +2483,7 @@ bool FJsEnvImpl::CheckDelegateProxies(float Tick)
             ClearDelegate(Isolate, Context, PendingToRemove[i]);
             if (!DelegateMap[PendingToRemove[i]].PassByPointer)
             {
-                delete ((FScriptDelegate*)PendingToRemove[i]);
+                delete ((FScriptDelegate*) PendingToRemove[i]);
             }
             DelegateMap.erase(PendingToRemove[i]);
         }


### PR DESCRIPTION
Fix: 修复使用 delegate 的对象频繁绑定可能引起内存非法访问崩溃的问题。