### PR TITLE
[unity] 重构wrapper.tpl，去掉ArgumentHelper。staticwrapper下性能优化10%-20%

### DIFF
--- a/unity/Assets/Puerts/Editor/Resources/puerts/templates/wrapper.tpl.mjs
+++ b/unity/Assets/Puerts/Editor/Resources/puerts/templates/wrapper.tpl.mjs
@@ -4,6 +4,7 @@
 * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may be subject to their corresponding license terms.
 * This file is subject to the terms and conditions defined in file 'LICENSE', which is part of this source code package.
 */
+import { default as $, IF, ELSE, ELSEIF, ENDIF, FOR } from './tte.mjs'
 
 class ArgumentCodeGenerator {
     constructor(i) {
@@ -42,13 +43,12 @@ class ArgumentCodeGenerator {
     getArg(typeInfo) {
         let typeName = typeInfo.TypeName;
         let isByRef = typeInfo.IsByRef ? "true" : "false";
-        
         if (typeInfo.IsParams) {
             return `${typeName}[] arg${this.index} = ArgHelper.GetParams<${typeName}>((int)data, isolate, info, ${this.index}, paramLen, ${this.v8Value()})`;
         } else if (typeInfo.IsEnum) {
             return `${typeName} arg${this.index} = (${typeName})StaticTranslate<${typeInfo.UnderlyingTypeName}>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${this.v8Value()}, ${isByRef})`;
         } else if (typeName in fixGet) {
-            return `${typeName} arg${this.index} = StaticTranslate<${typeName}>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${this.v8Value()}, ${isByRef})`;
+            return `${typeName} arg${this.index} = ${fixGet[typeName](this.v8Value(), isByRef)}`;
         } else {
             return `argobj${this.index} = argobj${this.index} != null ? argobj${this.index} : StaticTranslate<${typeInfo.TypeName}>.Get((int)data, isolate, NativeValueApi.GetValueFromArgument, v8Value${this.index}, ${typeInfo.IsByRef ? "true" : "false"}); ${typeName} arg${this.index} = (${typeName})argobj${this.index}`
         }
@@ -65,37 +65,36 @@ class ArgumentCodeGenerator {
 }
 
 const fixGet = {
-    char: (argHelperName, isByRef) => `StaticTranslate<char>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    sbyte: (argHelperName, isByRef) => `StaticTranslate<sbyte>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    byte: (argHelperName, isByRef) => `StaticTranslate<byte>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    short: (argHelperName, isByRef) => `StaticTranslate<short>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    ushort: (argHelperName, isByRef) => `StaticTranslate<ushort>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    int: (argHelperName, isByRef) => `StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    uint: (argHelperName, isByRef) => `StaticTranslate<uint>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    long: (argHelperName, isByRef) => `StaticTranslate<long>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    ulong: (argHelperName, isByRef) => `StaticTranslate<ulong>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    double: (argHelperName, isByRef) => `StaticTranslate<double>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    float: (argHelperName, isByRef) => `StaticTranslate<float>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    bool: (argHelperName, isByRef) => `StaticTranslate<bool>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    string: (argHelperName, isByRef) => `StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
-    DateTime: (argHelperName, isByRef) => `StaticTranslate<DateTime>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${argHelperName}.value, ${isByRef});`,
+    char: (v8ValueCode, isByRef) => `(char)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    sbyte: (v8ValueCode, isByRef) => `(sbyte)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    byte: (v8ValueCode, isByRef) => `(byte)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    short: (v8ValueCode, isByRef) => `(short)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    ushort: (v8ValueCode, isByRef) => `(ushort)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    int: (v8ValueCode, isByRef) => `(int)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    uint: (v8ValueCode, isByRef) => `(uint)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    long: (v8ValueCode, isByRef) => `(long)StaticTranslate<long>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${v8ValueCode}, ${isByRef});`,
+    ulong: (v8ValueCode, isByRef) => `(ulong)StaticTranslate<ulong>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, ${v8ValueCode}, ${isByRef});`,
+    double: (v8ValueCode, isByRef) => `(double)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    float: (v8ValueCode, isByRef) => `(float)PuertsDLL.GetNumberFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    bool: (v8ValueCode, isByRef) => `(bool)PuertsDLL.GetBooleanFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    string: (v8ValueCode, isByRef) => `(string)PuertsDLL.GetStringFromValue(isolate, ${v8ValueCode}, ${isByRef})`,
+    'System.DateTime': (v8ValueCode, isByRef) => `(new DateTime(1970, 1, 1)).AddMilliseconds(PuertsDLL.GetDateFromValue(isolate, ${v8ValueCode}, ${isByRef}))`,
 };
-
 const fixReturn = {
-    char: 'Puerts.StaticTranslate<char>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    sbyte: 'Puerts.StaticTranslate<sbyte>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    byte: 'Puerts.StaticTranslate<byte>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    short: 'Puerts.StaticTranslate<short>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    ushort: 'Puerts.StaticTranslate<ushort>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    int: 'Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    uint: 'Puerts.StaticTranslate<uint>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    long: 'Puerts.StaticTranslate<long>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    ulong: 'Puerts.StaticTranslate<ulong>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    double: 'Puerts.StaticTranslate<double>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    float: 'Puerts.StaticTranslate<float>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    bool: 'Puerts.StaticTranslate<bool>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    string: 'Puerts.StaticTranslate<string>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
-    DateTime: 'Puerts.StaticTranslate<DateTime>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result)',
+    char: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    sbyte: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    byte: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    short: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    ushort: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    int: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    uint: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    long: 'Puerts.PuertsDLL.ReturnBigInt(isolate, info, result)',
+    ulong: 'Puerts.PuertsDLL.ReturnBigInt(isolate, info, (long)result)',
+    double: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    float: 'Puerts.PuertsDLL.ReturnNumber(isolate, info, result)',
+    bool: 'Puerts.PuertsDLL.ReturnBoolean(isolate, info, result)',
+    string: 'Puerts.PuertsDLL.ReturnString(isolate, info, result)',
+    "System.DateTime": 'Puerts.PuertsDLL.ReturnDate(isolate, info, (result - new DateTime(1970, 1, 1)).TotalMilliseconds)',
 };
 const operatorMap = {
     op_Equality: '==',
@@ -169,235 +168,155 @@ export default function TypingTemplate(data) {
         return data.BlittableCopy ? "(*obj)" : "obj";
     }
 
-    function _es6tplJoin(str, ...values) {
-        return str.map((strFrag, index) => {
-            if (index == str.length - 1) {
-                return strFrag;
-
-            } else {
-                return strFrag + values[index];
-            }
-        }).join('');
-    }
-    function tt(str, ...values) {
-        // just append all estemplate values.
-        const appendtext = _es6tplJoin(str, ...values)
-
-        ret += appendtext;
-    }
-    function t(str, ...values) {
-        // just append all estemplate values. and indent them;
-        const appendtext = _es6tplJoin(str, ...values)
-
-        // indent
-        let lines = appendtext.split(/[\n\r]/);
-        let newLines = [lines[0]];
-        let append = " ".repeat(t.indent);
-        for (var i = 1; i < lines.length; i++) {
-            if (lines[i]) newLines.push(append + lines[i].replace(/^[\t\s]*/, ''));
-        }
-
-        ret += newLines.join('\n');
-    }
-
-    t.indent = 0;
-    toJsArray(data.Namespaces).forEach(name => {
-        t`
-        using ${name};
-        `
-    });
-
-    tt`using Puerts;
+    return $
+        `${FOR(toJsArray(data.Namespaces), name => `
+using ${name};`
+        )}
+using Puerts;
 
 namespace PuertsStaticWrap
 {
     public static class ${data.WrapClassName}${data.IsGenericWrapper ? `<${makeGenericAlphaBet(data.GenericArgumentsInfo)}>` : ''} ${data.IsGenericWrapper ? makeConstraints(data.GenericArgumentsInfo) : ''}
     {
-`
-    data.BlittableCopy && tt`
+    ${IF(data.BlittableCopy)}
         static ${data.Name} HeapValue;
-    `
-
-    // ==================== constructor start ====================
-    tt`
+    ${ENDIF()}
+    
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8ConstructorCallback))]
         ${data.BlittableCopy ? 'unsafe ' : ''}private static IntPtr Constructor(IntPtr isolate, IntPtr info, int paramLen, long data)
         {
             try
             {
-`
-    if (data.Constructor) {
-        toJsArray(data.Constructor.OverloadGroups).forEach(overloadGroup => {
-            if (data.Constructor.HasOverloads) {
-                tt`
+${IF(data.Constructor, () => $`
+    ${FOR(toJsArray(data.Constructor?.OverloadGroups), overloadGroup => {
+            var argumentCodeGenerators = toJsArray(overloadGroup.get_Item(0).ParameterInfos).map((v, i) => new ArgumentCodeGenerator(i));
+            $`
+            ${IF(data.Constructor.HasOverloads)}
                 if (${paramLenCheck(overloadGroup)})
-                `
-            }
-            tt`
+            ${ENDIF()}
                 {
-            `
-            var argumentCodeGenerators = [];
-            for (var i = 0; i < overloadGroup.get_Item(0).ParameterInfos.Length; i++) {
-                var acg = new ArgumentCodeGenerator(i);
-                argumentCodeGenerators.push(acg)
-                tt`
+                ${FOR(argumentCodeGenerators, acg => `
                     ${acg.declareAndGetV8Value()};
                     ${acg.declareArgObj()};
                     ${acg.declareArgJSValueType()};
-                `
-            }
-            toJsArray(overloadGroup).forEach(overload => {
-
-                if (data.Constructor.HasOverloads && overload.ParameterInfos.Length > 0) {
-                tt`
+                `)}
+                ${FOR(toJsArray(overloadGroup), overload =>
+                    $`
+                    ${IF(data.Constructor.HasOverloads && overload.ParameterInfos.Length > 0)}
                     if (${argumentCodeGenerators.map((acg, idx) => {
                         return acg.invokeIsMatch(overload.ParameterInfos.get_Item(idx))
                     }).join(' && ')})
-                `;
-                }
+                    ${ENDIF()}
 
-                tt`
                     {
-                `
-                argumentCodeGenerators.forEach((acg, idx) => {
-                    tt`
-                        ${acg.getArg(overload.ParameterInfos.get_Item(idx))};
-                    `
-                })
-                tt`
+                    ${FOR(argumentCodeGenerators, (acg, index) => `
+                        ${acg.getArg(overload.ParameterInfos.get_Item(index))};
+                    `)}
                         ${data.BlittableCopy ? "HeapValue" : "var result"} = new ${data.Name}(${argumentCodeGenerators.map((acg, idx) => {
-                            var paramInfo = overload.ParameterInfos.get_Item(idx);
-                            return `${paramInfo.IsOut ? "out " : (paramInfo.IsByRef ? (paramInfo.IsIn ? "in " : "ref ") : "")}${acg.arg()}`
-                        }).join(', ')});
-                `
-                argumentCodeGenerators.forEach((acg, idx) => {
-                    var paramInfo = overload.ParameterInfos.get_Item(idx)
-                    paramInfo.IsByRef && tt`
-                        StaticTranslate<${paramInfo.TypeName}>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, ${acg.v8Value()}, ${acg.arg()});
-                    `
-                })
-                if (data.BlittableCopy) {
-                    tt` 
+                        var paramInfo = overload.ParameterInfos.get_Item(idx);
+                        return `${paramInfo.IsOut ? "out " : (paramInfo.IsByRef ? (paramInfo.IsIn ? "in " : "ref ") : "")}${acg.arg()}`
+                    }).join(', ')});
+
+                    ${FOR(argumentCodeGenerators, (acg, idx) => {
+                        var paramInfo = overload.ParameterInfos.get_Item(idx)
+                        paramInfo.IsByRef && $`
+                        StaticTranslate<${paramInfo.TypeName}>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, ${acg.v8Value()}, ${acg.arg()});`
+                    })}
+
+                    ${IF(data.BlittableCopy)}
                         fixed (${data.Name}* result = &HeapValue)
                         {
                             return new IntPtr(result);
                         }
-                    `
-                } else {
-                    tt`
+                    ${ELSE()}
                         return Puerts.Utils.GetObjectPtr((int)data, typeof(${data.Name}), result);
-                    `
-                }
-                tt`
+                    ${ENDIF()}
                     }
-                `
-            })
-            tt`
+                    `)}
                 }
-            `
-        })
-    }
-    !data.Constructor || (data.Constructor.OverloadCount != 1) && tt`
+        `
+        })}
+`)}
+${IF(!data.Constructor || (data.Constructor.OverloadCount != 1))}
                 Puerts.PuertsDLL.ThrowException(isolate, "invalid arguments to " + typeof(${data.Name}).GetFriendlyName() + " constructor");
-    `
-    tt`
-    
+${ENDIF()}
             } catch (Exception e) {
                 Puerts.PuertsDLL.ThrowException(isolate, "c# exception:" + e.Message + ",stack:" + e.StackTrace);
             }
             return IntPtr.Zero;
         }
-    `
     // ==================== constructor end ====================
 
-
     // ==================== methods start ====================
-    toJsArray(data.Methods).filter(item => !item.IsLazyMember).forEach(method => {
-        tt`
+${FOR(toJsArray(data.Methods).filter(item => !item.IsLazyMember), method => $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         ${data.BlittableCopy && !method.IsStatic ? 'unsafe ' : ''}private static void ${(method.IsStatic ? "F" : "M")}_${method.Name}(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
             try
             {
                 ${!method.IsStatic ? `var obj = ${getSelf(data)};` : ''}
-        `
-        toJsArray(method.OverloadGroups).forEach(overloadGroup => {
-            if (method.HasOverloads) {
-                tt`
+        
+        ${FOR(toJsArray(method.OverloadGroups), overloadGroup => {
+            var argumentCodeGenerators = toJsArray(overloadGroup.get_Item(0).ParameterInfos)
+                // 这里取0可能是因为第一个重载参数肯定是最全的？
+                .map((item, i) => new ArgumentCodeGenerator(i));
+            $
+            `${IF(method.HasOverloads)}
                 if (${paramLenCheck(overloadGroup)})
-                `
-            }
-            tt`
+            ${ENDIF()}
                 {
-            `
-            var argumentCodeGenerators = [];
-
-            // 这里取0可能是因为第一个重载参数肯定是最全的？
-            for (var i = 0; i < overloadGroup.get_Item(0).ParameterInfos.Length; i++) {
-                var acg = new ArgumentCodeGenerator(i);
-                argumentCodeGenerators.push(acg)
-                tt`
+            
+                ${FOR(argumentCodeGenerators, acg => $`
                     ${acg.declareAndGetV8Value()};
                     ${acg.declareArgObj()};
                     ${acg.declareArgJSValueType()};
-                `
-            }
-            toJsArray(overloadGroup).forEach(overload => {
-                if (method.HasOverloads && overload.ParameterInfos.Length > 0) {
-                tt`
+                `)}
+                ${FOR(toJsArray(overloadGroup), overload => $`
+                    ${IF(method.HasOverloads && overload.ParameterInfos.Length > 0)}
                     if (${argumentCodeGenerators.map((acg, idx) => {
-                        return acg.invokeIsMatch(overload.ParameterInfos.get_Item(idx))
-                    }).join(' && ')})
-                `
-                }
-                tt`
+                return acg.invokeIsMatch(overload.ParameterInfos.get_Item(idx))
+            }).join(' && ')})
+                    ${ENDIF()}
                     {
-                `
-                argumentCodeGenerators.forEach((acg, idx) => {
-                    tt`
+                    ${FOR(argumentCodeGenerators, (acg, idx) => $`
                         ${acg.getArg(overload.ParameterInfos.get_Item(idx))};
-                    `
-                })
-                tt`
-                        ${overload.IsVoid ? "" : "var result = "}${method.IsStatic ? data.Name : refSelf()}.${UnK(method.Name)}(${argumentCodeGenerators.map((acg, idx) => {
+                    `)}
+
+                        ${overload.IsVoid ? "" : "var result = "}${method.IsStatic ? data.Name : refSelf()}.${UnK(method.Name)} (${argumentCodeGenerators.map((acg, idx) => {
                             var paramInfo = overload.ParameterInfos.get_Item(idx);
-                            return `${paramInfo.IsOut ? "out " : (paramInfo.IsByRef ? (paramInfo.IsIn ? "in " : "ref ") : "")}${acg.arg()}`
-                        }).join(', ')});
-                `
-                argumentCodeGenerators.forEach((acg, idx) => {
-                    overload.ParameterInfos.get_Item(idx).IsByRef && tt`
+                return `${paramInfo.IsOut ? "out " : (paramInfo.IsByRef ? (paramInfo.IsIn ? "in " : "ref ") : "")}${acg.arg()}`
+                            }).join(', ')
+                        });
+
+                    ${FOR(argumentCodeGenerators, (acg, idx) => $`
+                        ${IF(overload.ParameterInfos.get_Item(idx).IsByRef)}
                         StaticTranslate<${overload.ParameterInfos.get_Item(idx).TypeName}>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, ${acg.v8Value()}, ${acg.arg()});
-                    `
-                })
-                tt`
+                        ${ENDIF()}
+                    `)}
                         ${!overload.IsVoid ? setReturn(overload) + ';' : ''}
                         ${!data.BlittableCopy && !method.IsStatic ? setSelf(data) : ""}
                         ${method.HasOverloads ? 'return;' : ''}
                     }
-                `
-            })
-            tt`
+                `)}
                 }
             `
-        })
-        method.HasOverloads && tt`
+        })}
+        ${IF(method.HasOverloads)}
                 Puerts.PuertsDLL.ThrowException(isolate, "invalid arguments to ${method.Name}");
-        `
-        tt`
+        ${ENDIF()}
             }
             catch (Exception e)
             {
                 Puerts.PuertsDLL.ThrowException(isolate, "c# exception:" + e.Message + ",stack:" + e.StackTrace);
             }
         }
-        `
-    });
+`)}
     // ==================== methods end ====================
 
     // ==================== properties start ====================
-    toJsArray(data.Properties).filter(property => !property.IsLazyMember).forEach(property => {
-        if (property.HasGetter) {
-            tt`
+    ${FOR(toJsArray(data.Properties).filter(property => !property.IsLazyMember), property => {
+            if (property.HasGetter) {
+                $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         ${data.BlittableCopy && !property.IsStatic ? 'unsafe ' : ''}private static void G_${property.Name}(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
@@ -413,10 +332,10 @@ namespace PuertsStaticWrap
             }
         }
             `
-        }
-        if (property.HasSetter) {
-            var acg = new ArgumentCodeGenerator(0);
-            tt`
+            }
+            if (property.HasSetter) {
+                var acg = new ArgumentCodeGenerator(0);
+                $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         ${data.BlittableCopy && !property.IsStatic ? 'unsafe ' : ''}private static void S_${property.Name}(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
@@ -435,14 +354,13 @@ namespace PuertsStaticWrap
             }
         }
             `
-        }
-    })
+            }
+        })}
     // ==================== properties end ====================
-
     // ==================== array item get/set start ====================
-    if (data.GetIndexs.Length > 0) {
-        var acg = new ArgumentCodeGenerator(0);
-        tt`
+    ${IF(data.GetIndexs.Length > 0, () => {
+            var acg = new ArgumentCodeGenerator(0);
+            $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         ${data.BlittableCopy ? 'unsafe ' : ''}private static void GetItem(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
@@ -452,9 +370,7 @@ namespace PuertsStaticWrap
                 ${acg.declareAndGetV8Value()};
                 ${acg.declareArgObj()};
                 ${acg.declareArgJSValueType()};
-        `
-        toJsArray(data.GetIndexs).forEach(indexInfo => {
-            tt`
+            ${FOR(toJsArray(data.GetIndexs), indexInfo => $`
                 if (${acg.invokeIsMatch(indexInfo.IndexParameter)})
                 {
                     ${acg.getArg(indexInfo.IndexParameter)};
@@ -462,10 +378,7 @@ namespace PuertsStaticWrap
                     ${setReturn(indexInfo)};
                     return;
                 }
-            `;
-        })
-
-        tt`
+            `)}
             }
             catch (Exception e)
             {
@@ -473,10 +386,10 @@ namespace PuertsStaticWrap
             }
         }
         `
-    }
-    if (data.SetIndexs.Length > 0) {
-        var keyAcg = new ArgumentCodeGenerator(0);
-        tt`
+        })}
+    ${IF(data.SetIndexs.Length > 0, () => {
+            var keyAcg = new ArgumentCodeGenerator(0);
+            $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         ${data.BlittableCopy ? 'unsafe ' : ''}private static void SetItem(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
@@ -486,10 +399,10 @@ namespace PuertsStaticWrap
                 ${keyAcg.declareAndGetV8Value()};
                 ${keyAcg.declareArgObj()};
                 ${keyAcg.declareArgJSValueType()};
-        `
-        toJsArray(data.SetIndexs).forEach(indexInfo => {
-            var valueAcg = new ArgumentCodeGenerator(1);
-            tt`
+
+            ${FOR(toJsArray(data.SetIndexs), indexInfo => {
+                var valueAcg = new ArgumentCodeGenerator(1);
+                $`
                 if (${keyAcg.invokeIsMatch(indexInfo.IndexParameter)})
                 {
                     ${keyAcg.getArg(indexInfo.IndexParameter)};
@@ -500,10 +413,8 @@ namespace PuertsStaticWrap
 
                     ${refSelf()}[${keyAcg.arg()}] = ${valueAcg.arg()};
                     return;
-                }
-            `;
-        })
-        tt`
+                }`
+            })}
             }
             catch (Exception e)
             {
@@ -511,81 +422,62 @@ namespace PuertsStaticWrap
             }
         }
         `
-    }
+        })}
     // ==================== array item get/set end ====================
-
     // ==================== operator start ====================
-    toJsArray(data.Operators).filter(oper => !oper.IsLazyMember).forEach(operator => {
-        tt`
+    ${FOR(toJsArray(data.Operators).filter(oper => !oper.IsLazyMember), operator => $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         private static void O_${operator.Name}(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
             try
             {
-        `
-        toJsArray(operator.OverloadGroups).forEach(overloadGroup => {
-            operator.HasOverloads && tt`
+        ${FOR(toJsArray(operator.OverloadGroups), overloadGroup => {
+            var argumentCodeGenerators = toJsArray(overloadGroup.get_Item(0).ParameterInfos).map((v, i) => new ArgumentCodeGenerator(i));
+            $`
+                ${IF(operator.HasOverloads)}
                 if (${paramLenCheck(overloadGroup)})
-            `
-            tt`
+                ${ENDIF()}
                 {
-            `
-            var argumentCodeGenerators = [];
-            for (var i = 0; i < overloadGroup.get_Item(0).ParameterInfos.Length; i++) {
-                var acg = new ArgumentCodeGenerator(i);
-                argumentCodeGenerators.push(acg)
-                tt`
+                ${FOR(argumentCodeGenerators, (acg) => $`
                     ${acg.declareAndGetV8Value()};
                     ${acg.declareArgObj()};
                     ${acg.declareArgJSValueType()};
-                `
-            }
-            toJsArray(overloadGroup).forEach(overload => {
-                if (operator.HasOverloads && overload.ParameterInfos.Length > 0) {
-                    tt`
+                `)}
+                ${FOR(toJsArray(overloadGroup), overload => $`
+                    ${IF(operator.HasOverloads && overload.ParameterInfos.Length > 0)}
                     if (${argumentCodeGenerators.map((acg, idx) => {
-                        return acg.invokeIsMatch(overload.ParameterInfos.get_Item(idx))
-                    }).join(' && ')})
-                    `
-                }
-                tt`
+                return acg.invokeIsMatch(overload.ParameterInfos.get_Item(idx))
+            }).join(' && ')})
+                    ${ENDIF()}
+                    
                     {
-                `
-                argumentCodeGenerators.forEach((acg, idx) => {
-                    tt` 
+                    ${FOR(argumentCodeGenerators, (acg, idx) => $`
                         ${acg.getArg(overload.ParameterInfos.get_Item(idx))};
-                    `
-                })
-                tt`
+                    `)}
                         var result = ${operatorCall(operator.Name, argumentCodeGenerators, overload)};
                         ${!overload.IsVoid ? setReturn(overload) + ';' : ''}
                         ${operator.HasOverloads ? 'return;' : ''}
                     }
-                `
-            })
-            tt`
+                `)}
                 }
             `
-        })
-        operator.HasOverloads && tt`
+        })}
+        ${IF(operator.HasOverloads)}
                 Puerts.PuertsDLL.ThrowException(isolate, "invalid arguments to ${operator.Name}");
-        `
-        tt`
+        ${ENDIF()}
             }
             catch (Exception e)
             {
                 Puerts.PuertsDLL.ThrowException(isolate, "c# exception:" + e.Message + ",stack:" + e.StackTrace);
             }
         }
-        `
-    })
+    `)}
     // ==================== operator end ====================
-
     // ==================== events start ====================
-    toJsArray(data.Events).filter(ev => !ev.IsLazyMember).forEach(eventInfo => {
-        if (eventInfo.HasAdd) {
-            var acg = new ArgumentCodeGenerator(0);
-            tt`
+    ${FOR(toJsArray(data.Events).filter(ev => !ev.IsLazyMember), eventInfo => {
+            if (eventInfo.HasAdd) {
+                var acg = new ArgumentCodeGenerator(0);
+                $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         ${data.BlittableCopy && !eventInfo.IsStatic ? 'unsafe ' : ''}private static void A_${eventInfo.Name}(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
@@ -603,10 +495,10 @@ namespace PuertsStaticWrap
             }
         }
             `
-        }
-        if (eventInfo.HasRemove) {
-            var acg = new ArgumentCodeGenerator(0);
-            tt`
+            }
+            if (eventInfo.HasRemove) {
+                var acg = new ArgumentCodeGenerator(0);
+                $`
         [Puerts.MonoPInvokeCallback(typeof(Puerts.V8FunctionCallback))]
         ${data.BlittableCopy && !eventInfo.IsStatic ? 'unsafe' : ''}private static void R_${eventInfo.Name}(IntPtr isolate, IntPtr info, IntPtr self, int paramLen, long data)
         {
@@ -624,10 +516,10 @@ namespace PuertsStaticWrap
             }
         }
             `
-        }
-    })
+            }
+        })}
     // ==================== events end ====================
-    tt`    
+
         public static Puerts.TypeRegisterInfo GetRegisterInfo()
         {
             return new Puerts.TypeRegisterInfo()
@@ -671,9 +563,8 @@ namespace PuertsStaticWrap
                 }
             };
         }
-    `
-    if (data.BlittableCopy) {
-        tt`
+    ${IF(data.BlittableCopy, () => {
+            $`
         unsafe private static ${data.Name} StaticGetter(int jsEnvIdx, IntPtr isolate, Puerts.IGetValueFromJs getValueApi, IntPtr value, bool isByRef)
         {
             ${data.Name}* result = (${data.Name}*)getValueApi.GetNativeObject(isolate, value, isByRef);
@@ -689,7 +580,7 @@ namespace PuertsStaticWrap
                 setValueApi.SetNativeObject(isolate, value, typeId, new IntPtr(result));
             }
         }
-        
+
         public static void InitBlittableCopy(Puerts.JsEnv jsEnv)
         {
             Puerts.StaticTranslate<${data.Name}>.ReplaceDefault(StaticSetter, StaticGetter);
@@ -702,16 +593,14 @@ namespace PuertsStaticWrap
             });
         }
         `
-    }
-
-    tt`
+        })}
     }
 }
 `
-    return ret;
 }
 
 function toJsArray(csArr) {
+    if (!csArr) return [];
     let arr = [];
     for (var i = 0; i < csArr.Length; i++) {
         arr.push(csArr.get_Item(i));

--- a/unity/Assets/Puerts/Runtime/Src/Translator/ArgumentHelper.cs
+++ b/unity/Assets/Puerts/Runtime/Src/Translator/ArgumentHelper.cs
@@ -9,37 +9,46 @@ using System;
 
 namespace Puerts
 {
-    public struct ArgumentHelper
+    public struct ArgHelper
     {
-        private readonly int jsEnvIdx;
-        private readonly IntPtr isolate;
-        private readonly IntPtr value;
-        private readonly IntPtr info;
-        private JsValueType valueType;
-        private object obj;
-        private Type csType;
-
-        public ArgumentHelper(int jsEnvIdx, IntPtr isolate, IntPtr info, int index)
+        public static T[] GetParams<T>(int jsEnvIdx, IntPtr isolate, IntPtr info, int start, int end, IntPtr v8Value)
         {
-            this.jsEnvIdx = jsEnvIdx;
-            this.isolate = isolate;
-            this.info = info;
-            value = PuertsDLL.GetArgumentValue(info, index);
-            valueType = JsValueType.Invalid;
-            obj = null;
-            csType = null;
+            T[] result = new T[end - start];
+
+            for (int i = start; i < end; i++)
+            {
+                var val = PuertsDLL.GetArgumentValue(info, i);
+                result[i - start] = StaticTranslate<T>.Get(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, v8Value, false);
+            }
+
+            return result;
         }
 
-        public bool IsMatchParams(JsValueType expectJsType, Type expectCsType, int start, int end)
+        public static bool IsMatchParams(
+            int jsEnvIdx,
+            IntPtr isolate,
+            IntPtr info,
+
+            JsValueType expectJsType,
+            Type expectCsType,
+            int start,
+            int end,
+
+            IntPtr v8Value,
+            ref object arg,
+            ref JsValueType argValueType
+        )
         {
-            if (!IsMatch(expectJsType, expectCsType, false, false)) 
+            if (!IsMatch(jsEnvIdx, isolate, expectJsType, expectCsType, false, false,  v8Value, ref arg, ref argValueType))
             {
                 return false;
             }
             for (int i = start + 1; i < end; i++)
             {
-                var argHelper = new Puerts.ArgumentHelper(jsEnvIdx, isolate, info, i);
-                if (!argHelper.IsMatch(expectJsType, expectCsType, false, false))
+                IntPtr value = PuertsDLL.GetArgumentValue(info, i);
+                object argObj = null;
+                JsValueType valueType = JsValueType.Invalid;
+                if (!ArgHelper.IsMatch(jsEnvIdx, isolate,  expectJsType, expectCsType, false, false,  value, ref argObj, ref valueType))
                 {
                     return false;
                 }
@@ -48,59 +57,72 @@ namespace Puerts
             return true;
         }
 
-        public bool IsMatch(JsValueType expectJsType, Type expectCsType, bool isByRef, bool isOut)
+        public static bool IsMatch(
+            int jsEnvIdx,
+            IntPtr isolate,
+
+            JsValueType expectJsType,
+            Type expectCsType,
+            bool isByRef,
+            bool isOut,
+
+            IntPtr v8Value,
+            ref object arg,
+            ref JsValueType argValueType//,
+                                        // ref Type csType
+        )
         {
-            if (this.valueType == JsValueType.Invalid)
-                this.valueType = PuertsDLL.GetJsValueType(isolate, value, false);
-            var jsType = this.valueType;
-            if (jsType == JsValueType.JsObject)
+            Type csType = null;
+            if (argValueType == JsValueType.Invalid)
+                argValueType = PuertsDLL.GetJsValueType(isolate, v8Value, false);
+            if (argValueType == JsValueType.JsObject)
             {
-                if (isByRef) 
+                if (isByRef)
                 {
                     if (isOut) return true;
-                    jsType = PuertsDLL.GetJsValueType(isolate, value, true);
-                } 
-                else if ((expectJsType & jsType) == jsType)
+                    argValueType = PuertsDLL.GetJsValueType(isolate, v8Value, true);
+                }
+                else if ((expectJsType & argValueType) == argValueType)
                 {
                     return true;
                 }
-                else 
+                else
                 {
                     return false;
                 }
-            } 
+            }
 
-            if (jsType == JsValueType.NativeObject && expectCsType.IsPrimitive)
+            if (argValueType == JsValueType.NativeObject && expectCsType.IsPrimitive)
             {
-                if (obj == null)
+                if (arg == null)
                 {
-                    obj = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.AnyTranslator(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
+                    arg = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.AnyTranslator(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, v8Value, isByRef);
                 }
-                if (obj.GetType() == expectCsType) 
+                if (arg.GetType() == expectCsType)
                 {
                     return true;
                 }
             }
-            if ((expectJsType & jsType) != jsType)
+            if ((expectJsType & argValueType) != argValueType)
             {
                 return false;
             }
-            if (jsType == JsValueType.NativeObject)
+            if (argValueType == JsValueType.NativeObject)
             {
                 if (expectCsType.IsArray)
                 {
-                    if (obj == null)
+                    if (arg == null)
                     {
-                        obj = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.AnyTranslator(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
+                        arg = JsEnv.jsEnvs[jsEnvIdx].GeneralGetterManager.AnyTranslator(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, v8Value, isByRef);
                     }
 
-                    return expectCsType != null && expectCsType.IsAssignableFrom(obj.GetType());
+                    return expectCsType != null && expectCsType.IsAssignableFrom(arg.GetType());
                 }
                 else
                 {
                     if (csType == null)
                     {
-                        var typeId = NativeValueApi.GetValueFromArgument.GetTypeId(isolate, value, isByRef);
+                        var typeId = NativeValueApi.GetValueFromArgument.GetTypeId(isolate, v8Value, isByRef);
                         if (typeId >= 0)
                         {
                             csType = JsEnv.jsEnvs[jsEnvIdx].TypeRegister.GetType(typeId);
@@ -110,172 +132,6 @@ namespace Puerts
                 }
             }
             return true;
-        }
-
-
-
-        public char GetChar(bool isByRef)
-        {
-            return StaticTranslate<char>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(char val)
-        {
-            StaticTranslate<char>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);        
-        }
-
-        public sbyte GetSByte(bool isByRef)
-        {
-            return StaticTranslate<sbyte>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(sbyte val)
-        {
-            StaticTranslate<sbyte>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);        
-        }
-
-        public byte GetByte(bool isByRef)
-        {
-            return StaticTranslate<byte>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(byte val)
-        {
-            StaticTranslate<byte>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);        
-        }
-
-        public short GetInt16(bool isByRef)
-        {
-            return StaticTranslate<short>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(short val)
-        {
-            StaticTranslate<short>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);        
-        }
-
-        public ushort GetUInt16(bool isByRef)
-        {
-            return StaticTranslate<ushort>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(ushort val)
-        {
-            StaticTranslate<ushort>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public int GetInt32(bool isByRef)
-        {
-            return StaticTranslate<int>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(int val)
-        {
-            StaticTranslate<int>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public uint GetUInt32(bool isByRef)
-        {
-            return StaticTranslate<uint>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(uint val)
-        {
-            StaticTranslate<uint>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public long GetInt64(bool isByRef)
-        {
-            return StaticTranslate<long>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(long val)
-        {
-            StaticTranslate<long>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public ulong GetUInt64(bool isByRef)
-        {
-            return StaticTranslate<ulong>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(ulong val)
-        {
-            StaticTranslate<ulong>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public double GetDouble(bool isByRef)
-        {
-            return StaticTranslate<double>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(double val)
-        {
-            StaticTranslate<double>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public float GetFloat(bool isByRef)
-        {
-            return StaticTranslate<float>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(float val)
-        {
-            StaticTranslate<float>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public bool GetBoolean(bool isByRef)
-        {
-            return StaticTranslate<bool>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(bool val)
-        {
-            StaticTranslate<bool>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public string GetString(bool isByRef)
-        {
-            return StaticTranslate<string>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(string val)
-        {
-            StaticTranslate<string>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public DateTime GetDateTime(bool isByRef)
-        {
-            return StaticTranslate<DateTime>.Get(jsEnvIdx, isolate, Puerts.NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public void SetByRefValue(DateTime val)
-        {
-            StaticTranslate<DateTime>.Set(jsEnvIdx, isolate, Puerts.NativeValueApi.SetValueToByRefArgument, value, val);
-        }
-
-        public T Get<T>(bool isByRef)
-        {
-            if (obj != null) return (T)obj;
-            return StaticTranslate<T>.Get(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, value, isByRef);
-        }
-
-        public T[] GetParams<T>(IntPtr info, int start, int end)
-        {
-            T[] result = new T[end - start];
-
-            for(int i = start; i < end; i++)
-            {
-                var val = PuertsDLL.GetArgumentValue(info, i);
-                result[i - start] = StaticTranslate<T>.Get(jsEnvIdx, isolate, NativeValueApi.GetValueFromArgument, val, false);
-            }
-
-            return result;
-        }
-
-        public void SetByRefValue<T>(T val)
-        {
-            StaticTranslate<T>.Set(jsEnvIdx, isolate, NativeValueApi.SetValueToByRefArgument, value, val);
         }
     }
 

--- a/unity/Assets/Puerts/Runtime/Src/TypeRegister.cs
+++ b/unity/Assets/Puerts/Runtime/Src/TypeRegister.cs
@@ -920,6 +920,9 @@ namespace Puerts
 
         public Type GetType(int typeId)
         {
+            if (typeId == arrayTypeId) {
+                return typeof(System.Array);
+            }
             return typeMap[typeId];
         }
     }

--- a/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_GenericGenTest2_Wrap.cs
+++ b/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_GenericGenTest2_Wrap.cs
@@ -41,17 +41,21 @@ namespace PuertsStaticWrap
         
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.Get<System.Action<Puerts.UnitTest.WrapperTestBase>>(false);
+                        argobj1 = argobj1 != null ? argobj1 : StaticTranslate<System.Action<Puerts.UnitTest.WrapperTestBase>>.Get((int)data, isolate, NativeValueApi.GetValueFromArgument, v8Value1, false); System.Action<Puerts.UnitTest.WrapperTestBase> arg1 = (System.Action<Puerts.UnitTest.WrapperTestBase>)argobj1;
                     
-                        var result = obj.GetTypeTest(Arg0, Arg1);
+                        var result = obj.GetTypeTest(arg0, arg1);
                 
                         Puerts.ResultHelper.Set((int)data, isolate, info, result);
                         

--- a/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_MultiEnvTestA_Wrap.cs
+++ b/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_MultiEnvTestA_Wrap.cs
@@ -15,13 +15,15 @@ namespace PuertsStaticWrap
 
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var result = new Puerts.UnitTest.MultiEnvTestA(Arg0);
+                        var result = new Puerts.UnitTest.MultiEnvTestA(arg0);
                 
                         return Puerts.Utils.GetObjectPtr((int)data, typeof(Puerts.UnitTest.MultiEnvTestA), result);
                     

--- a/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_MultiEnvTestB_Wrap.cs
+++ b/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_MultiEnvTestB_Wrap.cs
@@ -15,13 +15,15 @@ namespace PuertsStaticWrap
 
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var result = new Puerts.UnitTest.MultiEnvTestB(Arg0);
+                        var result = new Puerts.UnitTest.MultiEnvTestB(arg0);
                 
                         return Puerts.Utils.GetObjectPtr((int)data, typeof(Puerts.UnitTest.MultiEnvTestB), result);
                     

--- a/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_OptionalParametersClass_Wrap.cs
+++ b/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_OptionalParametersClass_Wrap.cs
@@ -40,43 +40,49 @@ namespace PuertsStaticWrap
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.OptionalParametersClass;
         
                 if (paramLen == 3)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    var argHelper2 = new Puerts.ArgumentHelper((int)data, isolate, info, 2);
+                    IntPtr v8Value2 = PuertsDLL.GetArgumentValue(info, 2);
+                    object argobj2 = null;
+                    JsValueType argType2 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper2.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value2, ref argobj2, ref argType2))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var Arg2 = argHelper2.GetInt32(false);
+                        int arg2 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value2, false);
                     
-                        var result = obj.Test(Arg0, Arg1, Arg2);
+                        var result = obj.Test(arg0, arg1, arg2);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
                         return;
                     }
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper2.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value2, ref argobj2, ref argType2))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var Arg2 = argHelper2.GetInt32(false);
+                        int arg2 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value2, false);
                     
-                        var result = obj.Test(Arg0, Arg1, Arg2);
+                        var result = obj.Test(arg0, arg1, arg2);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -86,37 +92,41 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var result = obj.Test(Arg0, Arg1);
+                        var result = obj.Test(arg0, arg1);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
                         return;
                     }
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var result = obj.Test(Arg0, Arg1);
+                        var result = obj.Test(arg0, arg1);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -126,31 +136,33 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 1)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value0, ref argobj0, ref argType0))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var result = obj.Test(Arg0);
+                        var result = obj.Test(arg0);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
                         return;
                     }
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var result = obj.Test(Arg0);
+                        var result = obj.Test(arg0);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -160,7 +172,7 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 0)
-            
+                
                 {
             
                     {
@@ -191,18 +203,20 @@ namespace PuertsStaticWrap
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.OptionalParametersClass;
         
                 if (paramLen == 1)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var result = obj.Test2(Arg0);
+                        var result = obj.Test2(arg0);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -212,22 +226,26 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var result = obj.Test2(Arg0, Arg1);
+                        var result = obj.Test2(arg0, arg1);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -237,26 +255,32 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen >= 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    var argHelper2 = new Puerts.ArgumentHelper((int)data, isolate, info, 2);
+                    IntPtr v8Value2 = PuertsDLL.GetArgumentValue(info, 2);
+                    object argobj2 = null;
+                    JsValueType argType2 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper2.IsMatchParams(Puerts.JsValueType.Boolean, typeof(bool), 2, paramLen))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1) && ArgHelper.IsMatchParams((int)data, isolate, info, Puerts.JsValueType.Boolean, typeof(bool), 2, paramLen, v8Value2, ref argobj2, ref argType2))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var Arg2 = argHelper2.GetParams<bool>(info, 2, paramLen);
+                        bool[] arg2 = ArgHelper.GetParams<bool>((int)data, isolate, info, 2, paramLen, v8Value2);
                     
-                        var result = obj.Test2(Arg0, Arg1, Arg2);
+                        var result = obj.Test2(arg0, arg1, arg2);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -283,17 +307,21 @@ namespace PuertsStaticWrap
         
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var result = obj.Test3(Arg0, Arg1);
+                        var result = obj.Test3(arg0, arg1);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -317,30 +345,38 @@ namespace PuertsStaticWrap
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.OptionalParametersClass;
         
                 if (paramLen == 4)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    var argHelper2 = new Puerts.ArgumentHelper((int)data, isolate, info, 2);
+                    IntPtr v8Value2 = PuertsDLL.GetArgumentValue(info, 2);
+                    object argobj2 = null;
+                    JsValueType argType2 = JsValueType.Invalid;
                 
-                    var argHelper3 = new Puerts.ArgumentHelper((int)data, isolate, info, 3);
+                    IntPtr v8Value3 = PuertsDLL.GetArgumentValue(info, 3);
+                    object argobj3 = null;
+                    JsValueType argType3 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper2.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper3.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value2, ref argobj2, ref argType2) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value3, ref argobj3, ref argType3))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var Arg2 = argHelper2.GetInt32(false);
+                        int arg2 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value2, false);
                     
-                        var Arg3 = argHelper3.GetInt32(false);
+                        int arg3 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value3, false);
                     
-                        var result = obj.Test4(Arg0, Arg1, Arg2, Arg3);
+                        var result = obj.Test4(arg0, arg1, arg2, arg3);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -350,26 +386,32 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 3)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    var argHelper2 = new Puerts.ArgumentHelper((int)data, isolate, info, 2);
+                    IntPtr v8Value2 = PuertsDLL.GetArgumentValue(info, 2);
+                    object argobj2 = null;
+                    JsValueType argType2 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper2.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value2, ref argobj2, ref argType2))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var Arg2 = argHelper2.GetInt32(false);
+                        int arg2 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value2, false);
                     
-                        var result = obj.Test4(Arg0, Arg1, Arg2);
+                        var result = obj.Test4(arg0, arg1, arg2);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -379,22 +421,26 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var result = obj.Test4(Arg0, Arg1);
+                        var result = obj.Test4(arg0, arg1);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -420,26 +466,32 @@ namespace PuertsStaticWrap
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.OptionalParametersClass;
         
                 if (paramLen >= 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    var argHelper2 = new Puerts.ArgumentHelper((int)data, isolate, info, 2);
+                    IntPtr v8Value2 = PuertsDLL.GetArgumentValue(info, 2);
+                    object argobj2 = null;
+                    JsValueType argType2 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper2.IsMatchParams(Puerts.JsValueType.Boolean, typeof(bool), 2, paramLen))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1) && ArgHelper.IsMatchParams((int)data, isolate, info, Puerts.JsValueType.Boolean, typeof(bool), 2, paramLen, v8Value2, ref argobj2, ref argType2))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var Arg2 = argHelper2.GetParams<bool>(info, 2, paramLen);
+                        bool[] arg2 = ArgHelper.GetParams<bool>((int)data, isolate, info, 2, paramLen, v8Value2);
                     
-                        var result = obj.Test5(Arg0, Arg1, Arg2);
+                        var result = obj.Test5(arg0, arg1, arg2);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -449,22 +501,26 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var result = obj.Test5(Arg0, Arg1);
+                        var result = obj.Test5(arg0, arg1);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -490,26 +546,32 @@ namespace PuertsStaticWrap
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.OptionalParametersClass;
         
                 if (paramLen >= 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    var argHelper2 = new Puerts.ArgumentHelper((int)data, isolate, info, 2);
+                    IntPtr v8Value2 = PuertsDLL.GetArgumentValue(info, 2);
+                    object argobj2 = null;
+                    JsValueType argType2 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper2.IsMatchParams(Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), 2, paramLen))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1) && ArgHelper.IsMatchParams((int)data, isolate, info, Puerts.JsValueType.NullOrUndefined | Puerts.JsValueType.String, typeof(string), 2, paramLen, v8Value2, ref argobj2, ref argType2))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var Arg2 = argHelper2.GetParams<string>(info, 2, paramLen);
+                        string[] arg2 = ArgHelper.GetParams<string>((int)data, isolate, info, 2, paramLen, v8Value2);
                     
-                        var result = obj.Test6(Arg0, Arg1, Arg2);
+                        var result = obj.Test6(arg0, arg1, arg2);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -519,22 +581,26 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 2)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    var argHelper1 = new Puerts.ArgumentHelper((int)data, isolate, info, 1);
+                    IntPtr v8Value1 = PuertsDLL.GetArgumentValue(info, 1);
+                    object argobj1 = null;
+                    JsValueType argType1 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false) && argHelper1.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value0, ref argobj0, ref argType0) && ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value1, ref argobj1, ref argType1))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var Arg1 = argHelper1.GetInt32(false);
+                        int arg1 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value1, false);
                     
-                        var result = obj.Test6(Arg0, Arg1);
+                        var result = obj.Test6(arg0, arg1);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -544,18 +610,20 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 1)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.Number, typeof(int), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Number, typeof(int), false, false, v8Value0, ref argobj0, ref argType0))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetInt32(false);
+                        int arg0 = StaticTranslate<int>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var result = obj.Test6(Arg0);
+                        var result = obj.Test6(arg0);
                 
                         Puerts.StaticTranslate<int>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         
@@ -582,13 +650,15 @@ namespace PuertsStaticWrap
         
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
                     {
                 
-                        var Arg0 = argHelper0.GetString(false);
+                        string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        var result = obj.TestFilter(Arg0);
+                        var result = obj.TestFilter(arg0);
                 
                         Puerts.StaticTranslate<string>.Set((int)data, isolate, Puerts.NativeValueApi.SetValueToResult, info, result);
                         

--- a/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_WrapperTest_Wrap.cs
+++ b/unity/general/Src/UnitTest/wrap/Puerts_UnitTest_WrapperTest_Wrap.cs
@@ -40,7 +40,7 @@ namespace PuertsStaticWrap
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.WrapperTest;
         
                 if (paramLen == 0)
-            
+                
                 {
             
                     {
@@ -55,18 +55,20 @@ namespace PuertsStaticWrap
                 }
             
                 if (paramLen == 1)
-            
+                
                 {
             
-                    var argHelper0 = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
+                    IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                    object argobj0 = null;
+                    JsValueType argType0 = JsValueType.Invalid;
                 
-                    if (argHelper0.IsMatch(Puerts.JsValueType.Boolean, typeof(bool), false, false))
+                    if (ArgHelper.IsMatch((int)data, isolate, Puerts.JsValueType.Boolean, typeof(bool), false, false, v8Value0, ref argobj0, ref argType0))
                 
                     {
                 
-                        var Arg0 = argHelper0.GetBoolean(false);
+                        bool arg0 = StaticTranslate<bool>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
                     
-                        obj.GeneratedMethod(Arg0);
+                        obj.GeneratedMethod(arg0);
                 
                         
                         
@@ -105,8 +107,10 @@ namespace PuertsStaticWrap
             try
             {
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.WrapperTest;
-                var argHelper = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
-                obj.PropertyWithoutGetter = argHelper.GetString(false);
+                IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                object argobj0 = null;
+                string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
+                obj.PropertyWithoutGetter = arg0;
                 
             }
             catch (Exception e)
@@ -136,8 +140,10 @@ namespace PuertsStaticWrap
             try
             {
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.WrapperTest;
-                var argHelper = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
-                obj.Property = argHelper.GetString(false);
+                IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                object argobj0 = null;
+                string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
+                obj.Property = arg0;
                 
             }
             catch (Exception e)
@@ -167,8 +173,10 @@ namespace PuertsStaticWrap
             try
             {
                 
-                var argHelper = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
-                Puerts.UnitTest.WrapperTest.StaticProperty = argHelper.GetString(false);
+                IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                object argobj0 = null;
+                string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
+                Puerts.UnitTest.WrapperTest.StaticProperty = arg0;
                 
             }
             catch (Exception e)
@@ -198,8 +206,10 @@ namespace PuertsStaticWrap
             try
             {
                 var obj = Puerts.Utils.GetSelf((int)data, self) as Puerts.UnitTest.WrapperTest;
-                var argHelper = new Puerts.ArgumentHelper((int)data, isolate, info, 0);
-                obj.Field = argHelper.GetString(false);
+                IntPtr v8Value0 = PuertsDLL.GetArgumentValue(info, 0);
+                object argobj0 = null;
+                string arg0 = StaticTranslate<string>.Get((int)data, isolate, Puerts.NativeValueApi.GetValueFromArgument, v8Value0, false);
+                obj.Field = arg0;
                 
             }
             catch (Exception e)


### PR DESCRIPTION
性能优化主要在于减少StaticTranslate以及ArgumentHelper的使用。
但针对blittableCopy会用到的ReplaceGetSet，若是去掉StaticTranslate就无法工作了。因此非基础数据类型暂无做StaticTranslate的优化