### PR TITLE
[unity] 修复searchModuleInDir无法处理带"."符号的目录名

### DIFF
--- a/unity/Assets/Puerts/Runtime/Resources/puerts/cjsload.mjs
+++ b/unity/Assets/Puerts/Runtime/Resources/puerts/cjsload.mjs
@@ -43,15 +43,15 @@ function getFileExtension(filepath) {
     }
 }
 
+
 function searchModuleInDir(dir, requiredModule) {
-    if (getFileExtension(requiredModule)) {
-        return searchModuleInDirWithExt(dir, requiredModule);
-    } else {
-        return searchModuleInDirWithExt(dir, requiredModule + ".js")
-            || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
-            || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
-            || searchModuleInDirWithExt(dir, requiredModule + "/package.json");
-    }
+    // Some modules and dirnames also contains "." char. For example: "fs.realpath".
+    // In extreme cases. Some dirs meybe named with ".js".
+    return searchModuleInDirWithExt(dir, requiredModule)
+        || searchModuleInDirWithExt(dir, requiredModule + ".js")
+        || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
+        || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
+        || searchModuleInDirWithExt(dir, requiredModule + "/package.json");
 }
 
 function searchModule(dir, requiredModule) {


### PR DESCRIPTION
有一些node_modules的目录或子目录名会带有"."号, 导致require异常, 这里让所有目录都尝试加后缀去找module
@zombieyang 