### PR TITLE
[unity] 2.0.x fix for debug build

### DIFF
--- a/unity/native_src_il2cpp/Inc/Puerts_Module.h
+++ b/unity/native_src_il2cpp/Inc/Puerts_Module.h
@@ -45,7 +45,7 @@ namespace puerts_module
         // }
         v8::Local<v8::Function> ModuleResolveFunction = v8::Local<v8::Function>::Cast(Context->Global()->Get(Context, v8::String::NewFromUtf8(Isolate, "__puerts_resolve_module_content__").ToLocalChecked()).ToLocalChecked());
         v8::Local<v8::Module> Module;
-        char* pathForDebug;
+        const char* pathForDebug = *Specifier_utf8;
 
         std::vector< v8::Local<v8::Value>> V8Args;
         V8Args.push_back(Specifier);

--- a/unity/native_src_il2cpp/Src/PesapiV8Impl.cpp
+++ b/unity/native_src_il2cpp/Src/PesapiV8Impl.cpp
@@ -625,7 +625,7 @@ pesapi_value pesapi_eval(pesapi_env env, const uint8_t* code, size_t code_size, 
     v8::Local<v8::String> url =
         v8::String::NewFromUtf8(isolate, path == nullptr ? "" : path, v8::NewStringType::kNormal).ToLocalChecked();
     std::vector<char> buff;
-    buff.reserve(code_size + 1);
+    buff.resize(code_size + 1);
     memcpy(buff.data(), code, code_size);
     buff[code_size] = '\0';
     v8::Local<v8::String> source = v8::String::NewFromUtf8(isolate, buff.data(), v8::NewStringType::kNormal).ToLocalChecked();


### PR DESCRIPTION
1. buff.reserve will not acturally insert elements, then buff[code_size] = '\0'; will break debugger while in debug build
2. pathForDebug variable is not initialized, will break debugger while in debug build