### PR TITLE
[unity] csharp返回object，但是实际上是number时，JS侧得到数值无小数点的问题fix

### DIFF
--- a/unity/Assets/Puerts/Runtime/Src/Translator/DataTranslate.cs
+++ b/unity/Assets/Puerts/Runtime/Src/Translator/DataTranslate.cs
@@ -191,7 +191,7 @@ namespace Puerts
 
                     return result;
                 case JsValueType.Number:
-                    return getValueApi.GetNumber(isolate, value, isByRef);
+                    return DoubleTranslator(jsEnvIdx, isolate, getValueApi, value, isByRef);
                 case JsValueType.String:
                     return StringTranslator(jsEnvIdx, isolate, getValueApi, value, isByRef);
                 default:

--- a/unity/general/Src/UnitTest/TestClasses.cs
+++ b/unity/general/Src/UnitTest/TestClasses.cs
@@ -11,6 +11,17 @@ using System.Collections.Generic;
 
 namespace Puerts.UnitTest
 {
+    public class JSToCSCallTest
+    {
+        private static object _store;
+        public static void SetCSObjectStorage(object any) {
+            _store = any;
+        }
+        public static object GetCSObjectStorage() {
+            return _store;
+        }
+    }
+
     public class ParamsCallTest
     {
         public static string CombinePath(params object[] paths)

--- a/unity/general/Src/UnitTest/TestClasses.cs
+++ b/unity/general/Src/UnitTest/TestClasses.cs
@@ -43,8 +43,8 @@ namespace Puerts.UnitTest
             AENUM h = AENUM.b,
             byte i = 255,
             char j = char.MaxValue,
-            float k = float.PositiveInfinity,
-            IntPtr l = default(IntPtr)
+            float k = float.PositiveInfinity//,
+            // IntPtr l = default(IntPtr)
         )
         { return 1; }
         public static int PlaySound(string uid,Action onCompleted = default) 

--- a/unity/general/Src/UnitTest/TranslatorTest/JSToCSTest.cs
+++ b/unity/general/Src/UnitTest/TranslatorTest/JSToCSTest.cs
@@ -679,5 +679,17 @@ namespace Puerts.UnitTest.TranslatorTest
             jsEnv.Dispose();
             Assert.AreEqual(res, "a/b/c");
         }
+
+        [Test]
+        public void CSReturnObjectButIsNumberTest() {
+            var jsEnv = new JsEnv(new TxtLoader());
+            string res = jsEnv.Eval<string>(@"
+                CS.Puerts.UnitTest.JSToCSCallTest.SetCSObjectStorage(0.99);
+
+                CS.Puerts.UnitTest.JSToCSCallTest.GetCSObjectStorage().toString();
+            ");
+            jsEnv.Dispose();
+            Assert.AreEqual(res, "0.99");
+        }
     }
 }


### PR DESCRIPTION
同时修复mac ut不过的一个问题