### PR TITLE
structwrapper的functiontemplate也重用

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -787,6 +787,14 @@ FJsEnvImpl::~FJsEnvImpl()
         }
     }
 #endif
+
+#if PUERTS_REUSE_STRUCTWRAPPER_FUNCTIONTEMPLATE
+    for (auto Iter = TypeReflectionMap.CreateIterator(); Iter; ++Iter)
+    {
+        Iter->Value->CachedFunctionTemplate.Reset();
+    }
+#endif
+
     DefaultContext.Reset();
     MainIsolate->Dispose();
     MainIsolate = nullptr;
@@ -2698,10 +2706,9 @@ void FJsEnvImpl::UnBindContainer(void* Ptr)
     ContainerCache.Remove(Ptr);
 }
 
-std::shared_ptr<FStructWrapper> FJsEnvImpl::GetStructWrapper(UStruct* InStruct)
+std::shared_ptr<FStructWrapper> FJsEnvImpl::GetStructWrapper(UStruct* InStruct, bool& IsReuseTemplate)
 {
     const auto FullName = InStruct->GetFullName();
-
     auto TypeReflectionPtr = TypeReflectionMap.Find(FullName);
     if (!TypeReflectionPtr)
     {
@@ -2712,8 +2719,11 @@ std::shared_ptr<FStructWrapper> FJsEnvImpl::GetStructWrapper(UStruct* InStruct)
     }
     else
     {
+#if PUERTS_REUSE_STRUCTWRAPPER_FUNCTIONTEMPLATE
+        IsReuseTemplate = true;
+#endif
         // UE_LOG(LogTemp, Warning, TEXT("FJsEnvImpl::GetStructWrapper existed %s // %s"), *InStruct->GetName(), *FullName);
-        (*TypeReflectionPtr)->Init(InStruct);
+        (*TypeReflectionPtr)->Init(InStruct, IsReuseTemplate);
         return (*TypeReflectionPtr);
     }
 }
@@ -2731,7 +2741,8 @@ v8::Local<v8::FunctionTemplate> FJsEnvImpl::GetTemplateOfClass(UStruct* InStruct
         v8::EscapableHandleScope HandleScope(Isolate);
         v8::Local<v8::FunctionTemplate> Template;
 
-        auto StructWrapper = GetStructWrapper(InStruct);
+        bool IsReuseTemplate = false;
+        auto StructWrapper = GetStructWrapper(InStruct, IsReuseTemplate);
 
         auto ExtensionMethodsIter = ExtensionMethodsMap.find(InStruct);
         if (ExtensionMethodsIter != ExtensionMethodsMap.end())
@@ -2745,14 +2756,18 @@ v8::Local<v8::FunctionTemplate> FJsEnvImpl::GetTemplateOfClass(UStruct* InStruct
             // Logger->Warn(FString::Printf(TEXT("UScriptStruct: %s"), *InStruct->GetName()));
 
             Template = StructWrapper->ToFunctionTemplate(Isolate, FScriptStructWrapper::New);
+            if (!IsReuseTemplate)
+            {
 #if WITH_EDITOR
-            Template->SetClassName(
-                v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetPathName()), v8::NewStringType::kNormal)
-                    .ToLocalChecked());
+                Template->SetClassName(
+                    v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetPathName()), v8::NewStringType::kNormal)
+                        .ToLocalChecked());
 #elif !UE_SHIPPING
-            Template->SetClassName(
-                v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetName()), v8::NewStringType::kNormal).ToLocalChecked());
+                Template->SetClassName(
+                    v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetName()), v8::NewStringType::kNormal)
+                        .ToLocalChecked());
 #endif
+            }
             if (!ScriptStruct->IsNative())    //非原生的结构体，可能在实例没有的时候会释放
             {
                 SysObjectRetainer.Retain(ScriptStruct);
@@ -2762,7 +2777,10 @@ v8::Local<v8::FunctionTemplate> FJsEnvImpl::GetTemplateOfClass(UStruct* InStruct
             if (SuperStruct)
             {
                 bool Dummy;
-                Template->Inherit(GetTemplateOfClass(SuperStruct, Dummy));
+                if (IsReuseTemplate)
+                    __USE(GetTemplateOfClass(SuperStruct, Dummy));
+                else
+                    Template->Inherit(GetTemplateOfClass(SuperStruct, Dummy));
             }
         }
         else
@@ -2770,20 +2788,27 @@ v8::Local<v8::FunctionTemplate> FJsEnvImpl::GetTemplateOfClass(UStruct* InStruct
             auto Class = Cast<UClass>(InStruct);
             check(Class);
             Template = StructWrapper->ToFunctionTemplate(Isolate, FClassWrapper::New);
+            if (!IsReuseTemplate)
+            {
 #if WITH_EDITOR
-            Template->SetClassName(
-                v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetPathName()), v8::NewStringType::kNormal)
-                    .ToLocalChecked());
+                Template->SetClassName(
+                    v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetPathName()), v8::NewStringType::kNormal)
+                        .ToLocalChecked());
 #elif !UE_SHIPPING
-            Template->SetClassName(
-                v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetName()), v8::NewStringType::kNormal).ToLocalChecked());
+                Template->SetClassName(
+                    v8::String::NewFromUtf8(Isolate, TCHAR_TO_UTF8(*InStruct->GetName()), v8::NewStringType::kNormal)
+                        .ToLocalChecked());
 #endif
+            }
 
             auto SuperClass = Class->GetSuperClass();
             if (SuperClass)
             {
                 bool Dummy;
-                Template->Inherit(GetTemplateOfClass(SuperClass, Dummy));
+                if (IsReuseTemplate)
+                    __USE(GetTemplateOfClass(SuperClass, Dummy));
+                else
+                    Template->Inherit(GetTemplateOfClass(SuperClass, Dummy));
             }
         }
 
@@ -3988,7 +4013,8 @@ void FJsEnvImpl::Mixin(const v8::FunctionCallbackInfo<v8::Value>& Info)
     else
     {
         To->ClearFunctionMapsCaches();
-        auto StructWrapper = GetStructWrapper(To);
+        bool IsReuseTemplate = false;
+        auto StructWrapper = GetStructWrapper(To, IsReuseTemplate);
         for (int i = 0; i < ReplaceMethodNames.Num(); i++)
         {
             StructWrapper->RefreshMethod(To->FindFunctionByName(ReplaceMethodNames[i]));

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -269,7 +269,7 @@ private:
 
     void NewContainer(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
-    std::shared_ptr<FStructWrapper> GetStructWrapper(UStruct* InStruct);
+    std::shared_ptr<FStructWrapper> GetStructWrapper(UStruct* InStruct, bool& IsReuseTemplate);
 
     v8::Local<v8::FunctionTemplate> GetTemplateOfClass(UStruct* Class, bool& Existed);
 

--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Tencent is pleased to support the open source community by making Puerts available.
  * Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
  * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may
@@ -19,25 +19,25 @@ void FStructWrapper::AddExtensionMethods(std::vector<UFunction*> InExtensionMeth
 
 std::shared_ptr<FPropertyTranslator> FStructWrapper::GetPropertyTranslator(PropertyMacro* InProperty)
 {
-    auto Iter = PropertiesMap.find(InProperty->GetName());
-    if (Iter == PropertiesMap.end())
+    auto Iter = PropertiesMap.Find(InProperty->GetFName());
+    if (!Iter)
     {
         std::shared_ptr<FPropertyTranslator> PropertyTranslator = FPropertyTranslator::Create(InProperty);
         if (PropertyTranslator)
         {
-            PropertiesMap[InProperty->GetName()] = PropertyTranslator;
+            PropertiesMap.Add(InProperty->GetFName(), PropertyTranslator);
             Properties.push_back(PropertyTranslator);
         }
         return PropertyTranslator;
     }
-    FPropertyTranslator::CreateOn(InProperty, Iter->second.get());
-    return Iter->second;
+    FPropertyTranslator::CreateOn(InProperty, Iter->get());
+    return *Iter;
 }
 
 std::shared_ptr<FFunctionTranslator> FStructWrapper::GetMethodTranslator(UFunction* InFunction, bool IsExtension)
 {
-    auto Iter = MethodsMap.find(InFunction->GetName());
-    if (Iter == MethodsMap.end())
+    auto Iter = MethodsMap.Find(InFunction->GetFName());
+    if (!Iter)
     {
         std::shared_ptr<FFunctionTranslator> FunctionTranslator;
         if (IsExtension)
@@ -48,24 +48,24 @@ std::shared_ptr<FFunctionTranslator> FStructWrapper::GetMethodTranslator(UFuncti
         {
             FunctionTranslator = std::make_shared<FFunctionTranslator>(InFunction, false);
         }
-        MethodsMap[InFunction->GetName()] = FunctionTranslator;
+        MethodsMap.Add(InFunction->GetFName(), FunctionTranslator);
         return FunctionTranslator;
     }
-    Iter->second->Init(InFunction, false);
-    return Iter->second;
+    Iter->get()->Init(InFunction, false);
+    return *Iter;
 }
 
 std::shared_ptr<FFunctionTranslator> FStructWrapper::GetFunctionTranslator(UFunction* InFunction)
 {
-    auto Iter = FunctionsMap.find(InFunction->GetName());
-    if (Iter == FunctionsMap.end())
+    auto Iter = FunctionsMap.Find(InFunction->GetFName());
+    if (!Iter)
     {
         auto FunctionTranslator = std::make_shared<FFunctionTranslator>(InFunction, false);
-        FunctionsMap[InFunction->GetName()] = FunctionTranslator;
+        FunctionsMap.Add(InFunction->GetFName(), FunctionTranslator);
         return FunctionTranslator;
     }
-    Iter->second->Init(InFunction, false);
-    return Iter->second;
+    Iter->get()->Init(InFunction, false);
+    return *Iter;
 }
 
 void FStructWrapper::RefreshMethod(UFunction* InFunction)
@@ -76,54 +76,63 @@ void FStructWrapper::RefreshMethod(UFunction* InFunction)
     }
 }
 
-void FStructWrapper::InitTemplateProperties(v8::Isolate* Isolate, UStruct* InStruct, v8::Local<v8::FunctionTemplate> Template)
+void FStructWrapper::InitTemplateProperties(
+    v8::Isolate* Isolate, UStruct* InStruct, v8::Local<v8::FunctionTemplate> Template, bool IsReuseTemplate)
 {
     auto ClassDefinition = FindClassByType(Struct.Get());
-    TSet<FString> AddedProperties;
+    TSet<FName> AddedProperties;
     if (ClassDefinition)
     {
         JSPropertyInfo* PropertyInfo = ClassDefinition->Properties;
         while (PropertyInfo && PropertyInfo->Name && PropertyInfo->Getter)
         {
-            AddedProperties.Add(UTF8_TO_TCHAR(PropertyInfo->Name));
-            v8::PropertyAttribute PropertyAttribute = v8::DontDelete;
-            if (!PropertyInfo->Setter)
-                PropertyAttribute = (v8::PropertyAttribute)(PropertyAttribute | v8::ReadOnly);
-            auto Data = PropertyInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, PropertyInfo->Data))
-                                           : v8::Local<v8::Value>();
+            AddedProperties.Add(PropertyInfo->Name);
+            if (!IsReuseTemplate)
+            {
+                v8::PropertyAttribute PropertyAttribute = v8::DontDelete;
+                if (!PropertyInfo->Setter)
+                    PropertyAttribute = (v8::PropertyAttribute)(PropertyAttribute | v8::ReadOnly);
+                auto Data = PropertyInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, PropertyInfo->Data))
+                                               : v8::Local<v8::Value>();
 
-            Template->PrototypeTemplate()->SetAccessorProperty(FV8Utils::InternalString(Isolate, PropertyInfo->Name),
-                v8::FunctionTemplate::New(Isolate, PropertyInfo->Getter, Data),
-                v8::FunctionTemplate::New(Isolate, PropertyInfo->Setter, Data), PropertyAttribute);
+                Template->PrototypeTemplate()->SetAccessorProperty(FV8Utils::InternalString(Isolate, PropertyInfo->Name),
+                    v8::FunctionTemplate::New(Isolate, PropertyInfo->Getter, Data),
+                    v8::FunctionTemplate::New(Isolate, PropertyInfo->Setter, Data), PropertyAttribute);
+            }
             ++PropertyInfo;
         }
 
-        PropertyInfo = ClassDefinition->Variables;
-        while (PropertyInfo && PropertyInfo->Name && PropertyInfo->Getter)
+        if (!IsReuseTemplate)
         {
-            v8::PropertyAttribute PropertyAttribute = v8::DontDelete;
-            if (!PropertyInfo->Setter)
-                PropertyAttribute = (v8::PropertyAttribute)(PropertyAttribute | v8::ReadOnly);
-            auto Data = PropertyInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, PropertyInfo->Data))
-                                           : v8::Local<v8::Value>();
+            PropertyInfo = ClassDefinition->Variables;
+            while (PropertyInfo && PropertyInfo->Name && PropertyInfo->Getter)
+            {
+                v8::PropertyAttribute PropertyAttribute = v8::DontDelete;
+                if (!PropertyInfo->Setter)
+                    PropertyAttribute = (v8::PropertyAttribute)(PropertyAttribute | v8::ReadOnly);
+                auto Data = PropertyInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, PropertyInfo->Data))
+                                               : v8::Local<v8::Value>();
 
-            Template->SetAccessorProperty(FV8Utils::InternalString(Isolate, PropertyInfo->Name),
-                v8::FunctionTemplate::New(Isolate, PropertyInfo->Getter, Data),
-                v8::FunctionTemplate::New(Isolate, PropertyInfo->Setter, Data), PropertyAttribute);
-            ++PropertyInfo;
+                Template->SetAccessorProperty(FV8Utils::InternalString(Isolate, PropertyInfo->Name),
+                    v8::FunctionTemplate::New(Isolate, PropertyInfo->Getter, Data),
+                    v8::FunctionTemplate::New(Isolate, PropertyInfo->Setter, Data), PropertyAttribute);
+                ++PropertyInfo;
+            }
         }
     }
     for (TFieldIterator<PropertyMacro> PropertyIt(InStruct, EFieldIteratorFlags::ExcludeSuper); PropertyIt; ++PropertyIt)
     {
         PropertyMacro* Property = *PropertyIt;
-        if (AddedProperties.Contains(Property->GetName()))
+        if (AddedProperties.Contains(Property->GetFName()))
         {
             continue;
         }
+
         auto PropertyTranslator = GetPropertyTranslator(Property);
         if (PropertyTranslator)
         {
-            PropertyTranslator->SetAccessor(Isolate, Template);
+            if (!IsReuseTemplate)
+                PropertyTranslator->SetAccessor(Isolate, Template);
         }
         else
         {
@@ -136,12 +145,25 @@ v8::Local<v8::FunctionTemplate> FStructWrapper::ToFunctionTemplate(v8::Isolate* 
 {
     v8::EscapableHandleScope HandleScope(Isolate);
     auto ClassDefinition = FindClassByType(Struct.Get());
+    bool IsReuseTemplate = false;
+#if PUERTS_REUSE_STRUCTWRAPPER_FUNCTIONTEMPLATE
+    IsReuseTemplate = true;
+    if (CachedFunctionTemplate.IsEmpty())
+    {
+        IsReuseTemplate = false;
+        auto Temp = v8::FunctionTemplate::New(Isolate, Construtor, v8::External::New(Isolate, this));
+        Temp->InstanceTemplate()->SetInternalFieldCount(4);
+        CachedFunctionTemplate.Reset(Isolate, Temp);
+    }
+    auto Result = CachedFunctionTemplate.Get(Isolate);
+#else
     auto Result = v8::FunctionTemplate::New(
         Isolate, Construtor, v8::External::New(Isolate, this));    //和class的区别就这里传的函数不一样，后续尽量重用
     Result->InstanceTemplate()->SetInternalFieldCount(4);
+#endif
 
-    TSet<FString> AddedMethods;
-    TSet<FString> AddedFunctions;
+    TSet<FName> AddedMethods;
+    TSet<FName> AddedFunctions;
 
     if (ClassDefinition)
     {
@@ -150,26 +172,32 @@ v8::Local<v8::FunctionTemplate> FStructWrapper::ToFunctionTemplate(v8::Isolate* 
         JSFunctionInfo* FunctionInfo = ClassDefinition->Methods;
         while (FunctionInfo && FunctionInfo->Name && FunctionInfo->Callback)
         {
-            AddedMethods.Add(UTF8_TO_TCHAR(FunctionInfo->Name));
-            Result->PrototypeTemplate()->Set(FV8Utils::InternalString(Isolate, FunctionInfo->Name),
-                v8::FunctionTemplate::New(Isolate, FunctionInfo->Callback,
-                    FunctionInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, FunctionInfo->Data))
-                                       : v8::Local<v8::Value>()));
+            AddedMethods.Add(FunctionInfo->Name);
+            if (!IsReuseTemplate)
+            {
+                Result->PrototypeTemplate()->Set(FV8Utils::InternalString(Isolate, FunctionInfo->Name),
+                    v8::FunctionTemplate::New(Isolate, FunctionInfo->Callback,
+                        FunctionInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, FunctionInfo->Data))
+                                           : v8::Local<v8::Value>()));
+            }
             ++FunctionInfo;
         }
         FunctionInfo = ClassDefinition->Functions;
         while (FunctionInfo && FunctionInfo->Name && FunctionInfo->Callback)
         {
-            AddedFunctions.Add(UTF8_TO_TCHAR(FunctionInfo->Name));
-            Result->Set(FV8Utils::InternalString(Isolate, FunctionInfo->Name),
-                v8::FunctionTemplate::New(Isolate, FunctionInfo->Callback,
-                    FunctionInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, FunctionInfo->Data))
-                                       : v8::Local<v8::Value>()));
+            AddedFunctions.Add(FunctionInfo->Name);
+            if (!IsReuseTemplate)
+            {
+                Result->Set(FV8Utils::InternalString(Isolate, FunctionInfo->Name),
+                    v8::FunctionTemplate::New(Isolate, FunctionInfo->Callback,
+                        FunctionInfo->Data ? static_cast<v8::Local<v8::Value>>(v8::External::New(Isolate, FunctionInfo->Data))
+                                           : v8::Local<v8::Value>()));
+            }
             ++FunctionInfo;
         }
     }
 
-    InitTemplateProperties(Isolate, Struct.Get(), Result);
+    InitTemplateProperties(Isolate, Struct.Get(), Result, IsReuseTemplate);
 
     if (const auto Class = Cast<UClass>(Struct.Get()))
     {
@@ -177,8 +205,8 @@ v8::Local<v8::FunctionTemplate> FStructWrapper::ToFunctionTemplate(v8::Isolate* 
         {
             UFunction* Function = *FuncIt;
 
-            if ((Function->HasAnyFunctionFlags(FUNC_Static) && AddedFunctions.Contains(Function->GetName())) ||
-                (!Function->HasAnyFunctionFlags(FUNC_Static) && AddedMethods.Contains(Function->GetName())))
+            if ((Function->HasAnyFunctionFlags(FUNC_Static) && AddedFunctions.Contains(Function->GetFName())) ||
+                (!Function->HasAnyFunctionFlags(FUNC_Static) && AddedMethods.Contains(Function->GetFName())))
             {
                 // UE_LOG(LogTemp, Warning, TEXT("%s added"), *Function->GetName());
                 continue;
@@ -189,14 +217,16 @@ v8::Local<v8::FunctionTemplate> FStructWrapper::ToFunctionTemplate(v8::Isolate* 
             if (Function->HasAnyFunctionFlags(FUNC_Static))
             {
                 auto FunctionTranslator = GetFunctionTranslator(Function);
-                AddedFunctions.Add(Function->GetName());
-                Result->Set(Key, FunctionTranslator->ToFunctionTemplate(Isolate));
+                AddedFunctions.Add(Function->GetFName());
+                if (!IsReuseTemplate)
+                    Result->Set(Key, FunctionTranslator->ToFunctionTemplate(Isolate));
             }
             else
             {
                 auto FunctionTranslator = GetMethodTranslator(Function, false);
-                AddedMethods.Add(Function->GetName());
-                Result->PrototypeTemplate()->Set(Key, FunctionTranslator->ToFunctionTemplate(Isolate));
+                AddedMethods.Add(Function->GetFName());
+                if (!IsReuseTemplate)
+                    Result->PrototypeTemplate()->Set(Key, FunctionTranslator->ToFunctionTemplate(Isolate));
             }
         }
 
@@ -208,105 +238,116 @@ v8::Local<v8::FunctionTemplate> FStructWrapper::ToFunctionTemplate(v8::Isolate* 
                      ++ItfFuncIt)
                 {
                     UFunction* ItfFunction = *ItfFuncIt;
-                    if (!ItfFunction->HasAnyFunctionFlags(FUNC_Static) && !AddedMethods.Contains(ItfFunction->GetName()))
+                    if (!ItfFunction->HasAnyFunctionFlags(FUNC_Static) && !AddedMethods.Contains(ItfFunction->GetFName()))
                     {
                         auto ItfFunctionTranslator = GetMethodTranslator(ItfFunction, false);
-                        AddedMethods.Add(ItfFunction->GetName());
-                        Result->PrototypeTemplate()->Set(FV8Utils::InternalString(Isolate, ItfFunction->GetName()),
-                            ItfFunctionTranslator->ToFunctionTemplate(Isolate));
+                        AddedMethods.Add(ItfFunction->GetFName());
+                        if (!IsReuseTemplate)
+                            Result->PrototypeTemplate()->Set(FV8Utils::InternalString(Isolate, ItfFunction->GetName()),
+                                ItfFunctionTranslator->ToFunctionTemplate(Isolate));
                     }
                 }
             }
         }
-
-        Result->Set(
-            FV8Utils::InternalString(Isolate, "Find"), v8::FunctionTemplate::New(Isolate, Find, v8::External::New(Isolate, this)));
-        Result->Set(
-            FV8Utils::InternalString(Isolate, "Load"), v8::FunctionTemplate::New(Isolate, Load, v8::External::New(Isolate, this)));
+        if (!IsReuseTemplate)
+        {
+            Result->Set(FV8Utils::InternalString(Isolate, "Find"),
+                v8::FunctionTemplate::New(Isolate, Find, v8::External::New(Isolate, this)));
+            Result->Set(FV8Utils::InternalString(Isolate, "Load"),
+                v8::FunctionTemplate::New(Isolate, Load, v8::External::New(Isolate, this)));
+        }
     }
 
     for (auto Iter = ExtensionMethods.begin(); Iter != ExtensionMethods.end(); ++Iter)
     {
         UFunction* Function = *Iter;
 
-        if (AddedMethods.Contains(Function->GetName()))
+        if (AddedMethods.Contains(Function->GetFName()))
         {
             continue;
         }
 
         auto FunctionTranslator = GetMethodTranslator(Function, true);
 
-        auto Key = FV8Utils::InternalString(Isolate, Function->GetName());
-
-        AddedMethods.Add(Function->GetName());
-        Result->PrototypeTemplate()->Set(Key, FunctionTranslator->ToFunctionTemplate(Isolate));
+        AddedMethods.Add(Function->GetFName());
+        if (!IsReuseTemplate)
+        {
+            auto Key = FV8Utils::InternalString(Isolate, Function->GetName());
+            Result->PrototypeTemplate()->Set(Key, FunctionTranslator->ToFunctionTemplate(Isolate));
+        }
     }
 
-    Result->Set(FV8Utils::InternalString(Isolate, "StaticClass"),
-        v8::FunctionTemplate::New(Isolate, StaticClass, v8::External::New(Isolate, this)));
+    if (!IsReuseTemplate)
+        Result->Set(FV8Utils::InternalString(Isolate, "StaticClass"),
+            v8::FunctionTemplate::New(Isolate, StaticClass, v8::External::New(Isolate, this)));
 
-    if (!Struct->IsA<UClass>())
+    if (!Struct->IsA<UClass>() && !IsReuseTemplate)
     {
         Result->Set(FV8Utils::InternalString(Isolate, "StaticStruct"),
             v8::FunctionTemplate::New(Isolate, StaticClass, v8::External::New(Isolate, this)));
     }
 
 #ifndef WITH_QUICKJS
-    Result->InstanceTemplate()->SetHandler(v8::NamedPropertyHandlerConfiguration(
-        [](v8::Local<v8::Name> Property, const v8::PropertyCallbackInfo<v8::Value>& Info)
-        {
-            auto InnerIsolate = Info.GetIsolate();
-            auto Context = InnerIsolate->GetCurrentContext();
-            auto This = Info.This();
-            FName RequiredFName(*FV8Utils::ToFString(Info.GetIsolate(), Property));
-            auto FixedPropertyName = FV8Utils::ToV8String(InnerIsolate, RequiredFName);
-            if (This->GetPrototype()->IsObject())
+    if (!IsReuseTemplate)
+        Result->InstanceTemplate()->SetHandler(v8::NamedPropertyHandlerConfiguration(
+            [](v8::Local<v8::Name> Property, const v8::PropertyCallbackInfo<v8::Value>& Info)
             {
-                auto Proto = This->GetPrototype().As<v8::Object>();
-                if (Proto->Has(Context, FixedPropertyName).FromMaybe(false))
+                auto InnerIsolate = Info.GetIsolate();
+                auto Context = InnerIsolate->GetCurrentContext();
+                auto This = Info.This();
+                FName RequiredFName(*FV8Utils::ToFString(Info.GetIsolate(), Property));
+                auto FixedPropertyName = FV8Utils::ToV8String(InnerIsolate, RequiredFName);
+                if (This->GetPrototype()->IsObject())
                 {
-                    Info.GetReturnValue().Set(This->Get(Context, FixedPropertyName).ToLocalChecked());
-                    auto DescriptorVal = Proto->GetOwnPropertyDescriptor(Context, FixedPropertyName).ToLocalChecked();
-                    if (DescriptorVal->IsObject())
+                    auto Proto = This->GetPrototype().As<v8::Object>();
+                    if (Proto->Has(Context, FixedPropertyName).FromMaybe(false))
                     {
-                        auto Descriptor = DescriptorVal.As<v8::Object>();
-                        Proto->SetAccessorProperty(Property,
-                            Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "get")).ToLocalChecked().As<v8::Function>(),
-                            Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "set"))
-                                .ToLocalChecked()
-                                .As<v8::Function>());
+                        Info.GetReturnValue().Set(This->Get(Context, FixedPropertyName).ToLocalChecked());
+                        auto DescriptorVal = Proto->GetOwnPropertyDescriptor(Context, FixedPropertyName).ToLocalChecked();
+                        if (DescriptorVal->IsObject())
+                        {
+                            auto Descriptor = DescriptorVal.As<v8::Object>();
+                            Proto->SetAccessorProperty(Property,
+                                Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "get"))
+                                    .ToLocalChecked()
+                                    .As<v8::Function>(),
+                                Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "set"))
+                                    .ToLocalChecked()
+                                    .As<v8::Function>());
+                        }
                     }
                 }
-            }
-        },
-        [](v8::Local<v8::Name> Property, v8::Local<v8::Value> Value, const v8::PropertyCallbackInfo<v8::Value>& Info)
-        {
-            auto InnerIsolate = Info.GetIsolate();
-            auto Context = InnerIsolate->GetCurrentContext();
-            auto This = Info.This();
-            FName RequiredFName(*FV8Utils::ToFString(Info.GetIsolate(), Property));
-            auto FixedPropertyName = FV8Utils::ToV8String(InnerIsolate, RequiredFName);
-            if (This->GetPrototype()->IsObject())
+            },
+            [](v8::Local<v8::Name> Property, v8::Local<v8::Value> Value, const v8::PropertyCallbackInfo<v8::Value>& Info)
             {
-                auto Proto = This->GetPrototype().As<v8::Object>();
-                if (Proto->Has(Context, FixedPropertyName).FromMaybe(false))
+                auto InnerIsolate = Info.GetIsolate();
+                auto Context = InnerIsolate->GetCurrentContext();
+                auto This = Info.This();
+                FName RequiredFName(*FV8Utils::ToFString(Info.GetIsolate(), Property));
+                auto FixedPropertyName = FV8Utils::ToV8String(InnerIsolate, RequiredFName);
+                if (This->GetPrototype()->IsObject())
                 {
-                    auto _UnUsed = This->Set(Context, FixedPropertyName, Value);
-                    auto DescriptorVal = Proto->GetOwnPropertyDescriptor(Context, FixedPropertyName).ToLocalChecked();
-                    if (DescriptorVal->IsObject())
+                    auto Proto = This->GetPrototype().As<v8::Object>();
+                    if (Proto->Has(Context, FixedPropertyName).FromMaybe(false))
                     {
-                        auto Descriptor = DescriptorVal.As<v8::Object>();
-                        // set first, mush set accessor of object
-                        This->SetAccessorProperty(Property,
-                            Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "get")).ToLocalChecked().As<v8::Function>(),
-                            Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "set"))
-                                .ToLocalChecked()
-                                .As<v8::Function>());
+                        auto _UnUsed = This->Set(Context, FixedPropertyName, Value);
+                        auto DescriptorVal = Proto->GetOwnPropertyDescriptor(Context, FixedPropertyName).ToLocalChecked();
+                        if (DescriptorVal->IsObject())
+                        {
+                            auto Descriptor = DescriptorVal.As<v8::Object>();
+                            // set first, mush set accessor of object
+                            This->SetAccessorProperty(Property,
+                                Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "get"))
+                                    .ToLocalChecked()
+                                    .As<v8::Function>(),
+                                Descriptor->Get(Context, FV8Utils::ToV8String(InnerIsolate, "set"))
+                                    .ToLocalChecked()
+                                    .As<v8::Function>());
+                        }
                     }
                 }
-            }
-        },
-        nullptr, nullptr, nullptr, v8::Local<v8::Value>(), v8::PropertyHandlerFlags::kNonMasking));
+            },
+            nullptr, nullptr, nullptr, v8::Local<v8::Value>(), v8::PropertyHandlerFlags::kNonMasking));
 #endif
 
     return HandleScope.Escape(Result);

--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Tencent is pleased to support the open source community by making Puerts available.
  * Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
  * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may
@@ -23,6 +23,8 @@
 #include "v8.h"
 #pragma warning(pop)
 
+#define PUERTS_REUSE_STRUCTWRAPPER_FUNCTIONTEMPLATE 1
+
 namespace puerts
 {
 class FStructWrapper
@@ -32,27 +34,37 @@ public:
     {
     }
 
-    FORCEINLINE void Init(UStruct* InStruct)
+    FORCEINLINE void Init(UStruct* InStruct, bool IsReuseTemplate)
     {
-        ExternalInitialize = nullptr;
-        ExternalFinalize = nullptr;
         Struct = InStruct;
-        Properties.clear();
-        ExtensionMethods.clear();
+        if (!IsReuseTemplate)
+        {
+            ExternalInitialize = nullptr;
+            ExternalFinalize = nullptr;
+            Properties.clear();
+            ExtensionMethods.clear();
+#if PUERTS_REUSE_STRUCTWRAPPER_FUNCTIONTEMPLATE
+            CachedFunctionTemplate.Reset();
+#endif
+        }
     }
 
     void AddExtensionMethods(std::vector<UFunction*> InExtensionMethods);
 
+#if PUERTS_REUSE_STRUCTWRAPPER_FUNCTIONTEMPLATE
+    v8::UniquePersistent<v8::FunctionTemplate> CachedFunctionTemplate;
+#endif
+
 protected:
     std::vector<std::shared_ptr<FPropertyTranslator>> Properties;
 
-    std::map<FString, std::shared_ptr<FPropertyTranslator>> PropertiesMap;
+    TMap<FName, std::shared_ptr<FPropertyTranslator>> PropertiesMap;
 
     std::shared_ptr<FPropertyTranslator> GetPropertyTranslator(PropertyMacro* InProperty);
 
-    std::map<FString, std::shared_ptr<FFunctionTranslator>> FunctionsMap;
+    TMap<FName, std::shared_ptr<FFunctionTranslator>> FunctionsMap;
 
-    std::map<FString, std::shared_ptr<FFunctionTranslator>> MethodsMap;
+    TMap<FName, std::shared_ptr<FFunctionTranslator>> MethodsMap;
 
     std::shared_ptr<FFunctionTranslator> GetFunctionTranslator(UFunction* InFunction);
 
@@ -60,7 +72,8 @@ protected:
 
     void RefreshMethod(UFunction* InFunction);
 
-    void InitTemplateProperties(v8::Isolate* Isolate, UStruct* InStruct, v8::Local<v8::FunctionTemplate> Template);
+    void InitTemplateProperties(
+        v8::Isolate* Isolate, UStruct* InStruct, v8::Local<v8::FunctionTemplate> Template, bool IsReuseTemplate);
 
     v8::Local<v8::FunctionTemplate> ToFunctionTemplate(v8::Isolate* Isolate, v8::FunctionCallback Construtor);
 


### PR DESCRIPTION
functiontemplate会被slow cache引用，永不回收，导致一个bp被gc之后重新加载，会创建新的template产生泄露。
尝试过给functiontempllate增加no_cache的参数，发现每次GetFunction都会产生一个新的function，即便缓存该function，也会导致ts的内存显著增加，怀疑可能是newinstance对没有cache的template有特殊处理。