### PR TITLE
[unity] 2.0.x csharp module for #1055

### DIFF
--- a/unity/Assets/core/upm/Runtime/Resources/puerts/init_il2cpp.mjs
+++ b/unity/Assets/core/upm/Runtime/Resources/puerts/init_il2cpp.mjs
@@ -24,18 +24,26 @@ puer.loadType = function(nameOrCSType) {
     }
 }
 
-puer.getNestedTypes = function() {
-    // todo
+let typeof_System_RuntimeType = jsEnv.GetTypeByString("System.Type")
+let proto_System_Reflection_TypeInfo = typeof_System_RuntimeType.__proto__.__proto__
+let method_System_Type_GetNestedTypes = proto_System_Reflection_TypeInfo.GetNestedTypes
+puer.getNestedTypes = function(nameOrCSType) {
+    let csType = nameOrCSType
+    if (typeof nameOrCSType == "string") {
+        csType = jsEnv.GetTypeByString(nameOrCSType)
+    }
+    if (csType) {
+        return method_System_Type_GetNestedTypes.bind(csType)()
+    }
 }
+
 puer.getGenericMethod = function() {
     // todo
 }
 puer.getLastException = function() {
     // todo
 }
-puer.evalScript = global.jsEnv.Eval || function (script, debugPath) {
-    return eval(script);
-}
+puer.evalScript = eval
 
 let loader = jsEnv.GetLoader();
 function loadFile(path) {
@@ -50,3 +58,8 @@ function loadFile(path) {
 puer.loadFile = loadFile;
 
 puer.fileExists = loader.Resolve.bind(loader);
+
+// TODO: temporary polyfill Array.get_Item used in csharp.mjs
+let System_Array = puer.loadType("System.Array")
+let proto_System_Array = System_Array.prototype
+proto_System_Array.get_Item = proto_System_Array.GetValue

--- a/unity/native_src_il2cpp/Src/Puerts.cpp
+++ b/unity/native_src_il2cpp/Src/Puerts.cpp
@@ -534,7 +534,8 @@ struct JSEnv
 #endif
         CppObjectMapper.Initialize(Isolate, Context);
         Isolate->SetData(MAPPER_ISOLATE_DATA_POS, static_cast<ICppObjectMapper*>(&CppObjectMapper));
-        Isolate->SetData(1, &ModuleManager);
+        ModuleManager = new puerts::ModuleManager();
+        Isolate->SetData(1, ModuleManager);
         
         Context->Global()->Set(Context, v8::String::NewFromUtf8(Isolate, "loadType").ToLocalChecked(), v8::FunctionTemplate::New(Isolate, [](const v8::FunctionCallbackInfo<v8::Value>& Info)
         {
@@ -644,6 +645,7 @@ struct JSEnv
         }, &platform_finished);
         Platform->UnregisterIsolate(MainIsolate);
 #endif
+        delete ModuleManager;
         MainContext.Reset();
         MainIsolate->Dispose();
 #if WITH_NODEJS
@@ -668,7 +670,7 @@ struct JSEnv
     v8::Isolate::CreateParams* CreateParams;
     
     puerts::FCppObjectMapper CppObjectMapper;
-    puerts::ModuleManager ModuleManager;
+    puerts::ModuleManager* ModuleManager;
 
 #if defined(WITH_NODEJS)
     uv_loop_t* NodeUVLoop;

--- a/unity/test/Src/Cases/CSharpModuleTest.cs
+++ b/unity/test/Src/Cases/CSharpModuleTest.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+using System;
+
+namespace Puerts.UnitTest
+{
+    [TestFixture]
+    public class CSharpModuleTest
+    {
+        public class Inner {
+            [UnityEngine.Scripting.Preserve]
+            public const int i = 3;
+        }
+        [Test]
+        public void ConsoleLog()
+        {
+            var loader = UnitTestEnv.GetLoader();
+            loader.AddMockFileContent("CSharpModuleTest-ConsoleLog/test.mjs", @"
+                console.log('console.log ok')
+                CS.UnityEngine.Debug.Log('CS.UnityEngine.Debug.Log ok')
+            ");
+            var jsEnv = UnitTestEnv.GetEnv();
+            jsEnv.ExecuteModule("CSharpModuleTest-ConsoleLog/test.mjs");
+        }
+
+        [Test]
+        public void AccessInnerClass()
+        {
+            var loader = UnitTestEnv.GetLoader();
+            loader.AddMockFileContent("CSharpModuleTest-AccessInnerClass/test.mjs", @"
+                export default CS.Puerts.UnitTest.CSharpModuleTest.Inner.i
+            ");
+            var jsEnv = UnitTestEnv.GetEnv();
+            int res = jsEnv.ExecuteModule<int>("CSharpModuleTest-AccessInnerClass/test.mjs", "default");
+            Assert.AreEqual(res, Inner.i);
+        }
+    }
+}

--- a/unity/test/Src/Cases/CSharpModuleTest.cs.meta
+++ b/unity/test/Src/Cases/CSharpModuleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e0d4859e96750b42be6df09325395c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/test/Src/UnitTestLoader.cs
+++ b/unity/test/Src/UnitTestLoader.cs
@@ -31,7 +31,7 @@ namespace Puerts.UnitTest
             } 
             else if (UnityEngine.Resources.Load(FixSpecifier(specifier)) != null) 
             {
-                return "resouces/" + FixSpecifier(specifier);
+                return "resources/" + FixSpecifier(specifier);
             }
             return null;
         }
@@ -59,7 +59,7 @@ namespace Puerts.UnitTest
                     return;
 
                 } else if (specifier.StartsWith("resources/")) {
-                    content = UnityEngine.Resources.Load<UnityEngine.TextAsset>(specifier.Substring(9)).text;
+                    content = UnityEngine.Resources.Load<UnityEngine.TextAsset>(specifier.Substring(10)).text;
                     return;
                 }
             } 

--- a/unity/test/unity/Assets/link.xml
+++ b/unity/test/unity/Assets/link.xml
@@ -14,5 +14,9 @@
          <type fullname="Puerts.UnitTest.TestStruct" preserve="all"/>
          <type fullname="Puerts.UnitTest.TestHelper" preserve="all"/>
      </assembly>
+     <assembly fullname="mscorlib">
+         <type fullname="System.Type" preserve="all"/>
+         <type fullname="System.RuntimeType" preserve="all"/>
+     </assembly>
  
 </linker>


### PR DESCRIPTION
* fix bug in Puerts.cpp, ModuleManager.PathToModuleMap.clear() should be called before MainIsolate->Dispose();
* fix bug in UnitTestLoader, which will cause ExecuteModule takes no effect while loading scripts in Resources/
- implement puer.getNestedTypes
+ ConsoleLog test, AccessInnerClass test