### PR TITLE
[unity] v2 - support default value

### DIFF
--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/cppwrapper.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/cppwrapper.tpl.mjs
@@ -1,4 +1,4 @@
-import { FOR, default as t, IF, ENDIF, ELSE } from "./tte.mjs"
+import { FOR, default as t, IF, ENDIF, ELSE } from "./lib/tte.mjs"
 
 function listToJsArray(csArr) {
     let arr = [];

--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/extension_methods_gen.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/extension_methods_gen.tpl.mjs
@@ -1,4 +1,4 @@
-import { FOR } from './tte.mjs'
+import { FOR } from './lib/tte.mjs'
 
 export default function TypingTemplate(rawInfo) {
     return `

--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/lib/tte.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/lib/tte.mjs
@@ -196,10 +196,17 @@ export function ENDIF() {
     return TTEndif
 }
 export function FOR(arr, fn, joiner = '') {
-    if (!arr || !(arr instanceof Array)) return '';
+    if (!arr || !(arr instanceof Array || typeof arr[Symbol.iterator] === 'function')) return '';
 
     let scope = enterScope();
-    let ret = arr.map(fn);
+    let ret;
+    if (arr.map) ret = arr.map(fn);
+    else {
+        ret = [];
+        for (let item of arr) {
+            ret.push(fn(item));
+        }
+    }
     var resultInScope = exitScope(scope);
 
     if (ret.filter(item => item !== void 0) == 0) {

--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/linkxmlgen.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/linkxmlgen.tpl.mjs
@@ -1,4 +1,4 @@
-import { FOR } from './tte.mjs'
+import { FOR } from './lib/tte.mjs'
 
 export default function TypingTemplate(genTypes) {
     return `

--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/methodwrapper.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/methodwrapper.tpl.mjs
@@ -1,0 +1,194 @@
+import { FOR, default as t } from "./lib/tte.mjs"
+
+class WrapperInfo {
+
+    constructor(methodInfo, constructorInfo, parameterInfos) {
+        this.methodInfo = methodInfo;
+        this.constructorInfo = constructorInfo;
+        this.parameterInfos = parameterInfos;
+
+        this.sign = `${this.constructorInfo ? 'ctor' : this.methodInfo.Name}(${
+            parameterInfos.map(p => p.ParameterType).join(',')
+        })`
+        this.forDistinct = false;
+    }
+}
+
+const DictStrStr = puer.$generic(CS.System.Collections.Generic.Dictionary$2, CS.System.String, CS.System.String);
+const typeof_ParamArrayAttribute = puer.$typeof(CS.System.ParamArrayAttribute);
+export function GenByMethodInfoAndConstructorInfo(mis, cis) {
+    const misJSArr = listToJsArray(mis)
+    const cisJSArr = listToJsArray(cis)
+
+    const infoMap = new Map();
+    misJSArr.forEach(mi => {
+        const pis = mi.GetParameters();
+        const wiForDistinct = new WrapperInfo(mi, null, listToJsArray(pis));
+        wiForDistinct.forDistinct = true;
+        const typeWrapInfos = infoMap.get(mi.DeclaringType) || {};
+        typeWrapInfos[wiForDistinct.sign] = wiForDistinct;
+
+        for (let i = pis.Length - 1; i >= 0; i--) {
+            const pi = pis.get_Item(i);
+            if (!pi.IsOptional && !pi.IsDefined(typeof_ParamArrayAttribute, false)) break;
+
+            const wi = new WrapperInfo(mi, null, listToJsArray(pis, {take: i}));
+            if (!(wi.sign in typeWrapInfos)) {
+                typeWrapInfos[wi.sign] = wi;
+            } else {
+                typeWrapInfos[wi.sign] = null;
+            }
+            infoMap.set(mi.DeclaringType, typeWrapInfos);
+        }
+    })
+    cisJSArr.forEach(ci => {
+        const pis = ci.GetParameters();
+        const wiForDistinct = new WrapperInfo(null, ci, listToJsArray(pis));
+        wiForDistinct.forDistinct = true;
+        const typeWrapInfos = infoMap.get(ci.DeclaringType) || {};
+        typeWrapInfos[wiForDistinct.sign] = wiForDistinct;
+
+        for (let i = pis.Length - 1; i >= 0; i--) {
+            const pi = pis.get_Item(i);
+            if (!pi.IsOptional && !pi.IsDefined(typeof_ParamArrayAttribute, false)) break;
+
+            const wi = new WrapperInfo(null, ci, listToJsArray(pis, {take: i}));
+            if (!(wi.sign in typeWrapInfos)) {
+                typeWrapInfos[wi.sign] = wi;
+            } else {
+                typeWrapInfos[wi.sign] = null;
+            }
+            infoMap.set(ci.DeclaringType, typeWrapInfos);
+        }
+    });
+
+    const dict = new DictStrStr();
+    for (let type of infoMap.keys()) {
+        const wis = infoMap.get(type);
+        Object.keys(wis).forEach(key=> {
+            if (wis[key] == null || wis[key].forDistinct) {
+                delete wis[key];
+            }
+        })
+        if (Object.keys(wis).length == 0) {
+            infoMap.delete(type);
+        } else {
+            infoMap.set(type, wis);
+            dict.Add(getWrapperName(type) + "_PuerDVAdaptor.cs", renderAdaptor(type, infoMap.get(type)));
+        }
+    }
+
+    dict.Add("DefaultValueAdaptors.cs", renderRegister(infoMap.keys()))
+
+    return dict;
+}
+
+function renderRegister(types) {
+    return t`using System;
+using System.Collections.Generic;
+
+namespace PuertsStaticWrap
+{
+    public static class DefaultValueAdaptors
+    {
+        public static Dictionary<Type, Type> AdaptorsDict = new Dictionary<Type, Type>
+        {
+            ${FOR(types, type => {
+                return `
+            {typeof(${friendyNameWithoutGenericArguments(type.GetFriendlyName())}), typeof(${getWrapperName(type) + "_PuerDVAdaptor"})},
+            `
+            })}
+        };
+    }
+}`
+}
+
+function renderAdaptor(type, wrapperInfoKV) {
+    const isGenericType = type.IsGenericType;
+
+    return t`namespace PuertsStaticWrap {
+    // ${CS.System.IO.Path.GetFileName(type.Assembly.Location)}
+    public static class ${getWrapperName(type)}_PuerDVAdaptor {
+    ${FOR(Object.values(wrapperInfoKV), item=> {
+        if (item.constructorInfo) {
+            return `
+        public static ${item.constructorInfo.DeclaringType.GetFriendlyName()} ctor${isGenericType ? `<${listToJsArray(type.GetGenericArguments()).map(ga=> ga.Name).join(', ')}>` : ''} (
+            ${
+                item.parameterInfos
+                    .map((pi, index)=> (pi.ParameterType.IsByRef ? pi.ParameterType.GetElementType() : pi.ParameterType).GetFriendlyName() + " p" + index)
+                    .join(', ')
+            }
+        )${isGenericType ? makeConstraints(listToJsArray(type.GetGenericArguments())) : ''} {
+            return new ${item.constructorInfo.DeclaringType.GetFriendlyName()}(${item.parameterInfos.map((pi, index)=> refPrefix(pi) + "p" + index).join(', ')});
+        }
+            `;
+
+        } else {
+            return `
+        public static ${item.methodInfo.ReturnType.GetFriendlyName()} ${item.methodInfo.Name}${isGenericType ? `<${listToJsArray(type.GetGenericArguments()).map(ga=> ga.Name).join(', ')}>` : ''} (
+            ${
+                [item.methodInfo.IsStatic ? '' : item.methodInfo.DeclaringType.GetFriendlyName() + " __this"]
+                    .concat(item.parameterInfos.map((pi, index)=> (pi.ParameterType.IsByRef ? pi.ParameterType.GetElementType() : pi.ParameterType).GetFriendlyName() + " p" + index))
+                    .filter(p=> p)
+                    .join(', ')
+            }
+        )${isGenericType ? makeConstraints(listToJsArray(type.GetGenericArguments())) : ''} {
+            ${item.methodInfo.ReturnType == puer.$typeof(CS.System.Void) ? '' : 'return '}${item.methodInfo.IsStatic ? item.methodInfo.DeclaringType.GetFriendlyName() : '__this'}.${item.methodInfo.Name}(${item.parameterInfos.map((pi, index)=> refPrefix(pi) + "p" + index).join(', ')});
+        }
+            `;
+        }
+    })}
+    }
+}`;
+}
+
+function listToJsArray(csArr, { take } = {}) {
+    let arr = [];
+    if (!csArr) return arr;
+    const length = typeof(take) == 'undefined' ? csArr.Length : take;
+    for (var i = 0; i < length; i++) {
+        arr.push(csArr.get_Item(i));
+    }
+    return arr;
+}
+function getWrapperName(type) {
+    return type.ToString().replaceAll("+", "_").replaceAll(".", "_").replaceAll("`", "_").replaceAll("&", "_").replaceAll("[", "_").replaceAll("]", "_").replaceAll(",", "_");
+}
+function refPrefix(paramInfo) {
+    return `${paramInfo.IsOut ? "out " : (paramInfo.IsByRef ? (paramInfo.IsIn ? "in " : "ref ") : "")}`
+}
+const GenericParameterAttributes = CS.System.Reflection.GenericParameterAttributes;
+function makeConstraints(gas) {
+    const ret = [];
+    for (var i = 0; i < gas.length; i++) {
+        const ga = gas[i];
+        var consstr = [];
+
+        var contraintTypes = listToJsArray(ga.GetGenericParameterConstraints());
+        var constraints = ga.GenericParameterAttributes &
+        GenericParameterAttributes.SpecialConstraintMask;
+
+        var hasValueTypeConstraint = false;
+        for (var j = 0; j < contraintTypes.length; j++)
+        {
+            if (contraintTypes[j] == puer.$typeof(CS.System.ValueType))
+            {
+                hasValueTypeConstraint = true;
+                continue;
+            }
+            consstr.push(contraintTypes[j].GetFriendlyName());
+        }
+        if ((constraints & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+            consstr.unshift("class");
+        if (hasValueTypeConstraint && (constraints & GenericParameterAttributes.DefaultConstructorConstraint) != 0 && (constraints & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+            consstr.push("struct");
+        else if ((constraints & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
+            consstr.push("new()");
+
+        consstr.length && ret.push(`where ${ga.Name} : ` + consstr.join(', '))
+    }
+    return ' ' + ret.join(' ');
+}
+function friendyNameWithoutGenericArguments(name) {
+    return name.replace(/<([\w\s,])*>/, '<>');
+}

--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/wrapper.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/wrapper.tpl.mjs
@@ -4,7 +4,7 @@
 * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may be subject to their corresponding license terms.
 * This file is subject to the terms and conditions defined in file 'LICENSE', which is part of this source code package.
 */
-import { default as $, IF, ELSE, ELSEIF, ENDIF, FOR } from './tte.mjs'
+import { default as $, IF, ELSE, ELSEIF, ENDIF, FOR } from './lib/tte.mjs'
 
 class ArgumentCodeGenerator {
     constructor(i) {

--- a/unity/Assets/core/upm/Editor/Src/Generator/IL2Cpp/FileExporter.cs
+++ b/unity/Assets/core/upm/Editor/Src/Generator/IL2Cpp/FileExporter.cs
@@ -17,6 +17,44 @@ namespace PuertsIl2cpp.Editor
 {
     namespace Generator {
         public class FileExporter {
+            // private static string[] excludeAssemblys = {
+            //     "ExCSS.Unity.dll",
+            //     "SyntaxTree.VisualStudio.Unity.Messaging.dll",
+            //     "SyntaxTree.VisualStudio.Unity.Bridge.dll",
+            //     "Mono.Security.dll",
+            //     "UnityEngine.TestRunner.dll",
+            //     "Unity.Analytics.StandardEvents.dll",
+            //     "Unity.Timeline.Editor.dll",
+            //     "Unity.Analytics.Tracker.dll",
+            //     "Unity.Analytics.Editor.dll",
+            //     "System.Numerics.dll",
+            //     "nunit.framework.dll",
+            //     "Newtonsoft.Json.dll",
+            //     "Unity.2D.Sprite.Editor.dll"
+            // };
+            // private static bool IsAssemblyExcluded(string assemblyLocation, bool excludePuerts = false) {
+            //     bool ret = excludeAssemblys.Contains(assemblyLocation) || assemblyLocation.Contains("UnityEditor");
+            //     // UnityEngine.Debug.Log(assemblyLocation + " => " + ret);
+            //     if (excludePuerts) 
+            //     {
+            //         ret = ret || (assemblyLocation.Contains("com.tencent.puerts.core.dll") || assemblyLocation.Contains("com.tencent.puerts.core.Editor.dll"));
+            //     }   
+            //     return ret;
+            // }
+            // private static bool IsTypeExcluded(Type type) {
+            //     string Namespace = type.Namespace != null ? type.Namespace : "";
+            //     return type == typeof(System.IO.Stream) || 
+            //         type == typeof(System.IO.Compression.GZipStream) || 
+            //         type == typeof(System.AppDomain) ||
+            //         type.FullName.Contains("System.Memory") || 
+            //         type.FullName.Contains("System.ReadOnlyMemory") ||
+            //         Namespace.Contains("System.CodeDom") ||
+            //         Namespace == "System.Reflection.Emit" ||
+            //         Namespace == "System.Diagnostics" || 
+            //         (Namespace.Contains("System") && type.FullName.Contains("Internal")) || 
+            //         Namespace.Contains("System.Configuration");
+            // }
+
             public static List<string> GetValueTypeFieldSignatures(Type type)
             {
                 List<string> ret = (type.BaseType != null && type.BaseType.IsValueType) ? GetValueTypeFieldSignatures(type.BaseType) : new List<string>();
@@ -61,9 +99,62 @@ namespace PuertsIl2cpp.Editor
                 public List<SignatureInfo> FieldWrapperInfos;
             }
 
+            class MethodWrapInfo
+            {
+                public MethodInfo MethodInfo;
+                public ConstructorInfo ConstructorInfo;
+                public bool IsConstructor;
+                public ParameterInfo[] ParameterInfos;
+            }
+
             public static Type GetUnrefParameterType(ParameterInfo parameterInfo)
             {
                 return (parameterInfo.ParameterType.IsByRef || parameterInfo.ParameterType.IsPointer) ? parameterInfo.ParameterType.GetElementType() : parameterInfo.ParameterType;
+            }
+
+            public static void GenMethodWithDefaultValue(string saveTo)
+            {
+                var configure = Puerts.Configure.GetConfigureByTags(new List<string>() {
+                        "Puerts.BindingAttribute",
+                    });
+                    
+                var types = new HashSet<Type>(configure["Puerts.BindingAttribute"].Select(kv => kv.Key)
+                    .Where(o => o is Type)
+                    .Cast<Type>()
+                    .Distinct()
+                    .ToList());
+
+                const BindingFlags flag = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
+                const BindingFlags flagForPuer = BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+                
+                var typeExcludeDelegate = types
+                    .Where(t => !typeof(MulticastDelegate).IsAssignableFrom(t));
+
+                var ctorToWrap = typeExcludeDelegate
+                    .SelectMany(t => t.GetConstructors(t.FullName.Contains("Puer") ? flagForPuer : flag))
+                    .Where(m=> !Utils.IsNotSupportedMember(m))
+                    .ToArray();
+
+                var methodToWrap = typeExcludeDelegate
+                    .SelectMany(t => t.GetMethods(t.FullName.Contains("Puer") ? flagForPuer : flag))
+                    .Where(m=> !Utils.IsNotSupportedMember(m))
+                    .Where(m=> !m.IsGenericMethod)
+                    .ToArray();
+
+                using (var jsEnv = new Puerts.JsEnv())
+                {
+                    jsEnv.UsingFunc<MethodInfo[], ConstructorInfo[], Dictionary<string, string>>();
+                    Dictionary<string, string> wrapperContents = jsEnv.ExecuteModule<Func<MethodInfo[], ConstructorInfo[], Dictionary<string, string>>>("puerts/templates/methodwrapper.tpl.mjs", "GenByMethodInfoAndConstructorInfo")(methodToWrap, ctorToWrap);
+
+                    foreach (KeyValuePair<string, string> wrapper in wrapperContents)
+                    {
+                        using (StreamWriter textWriter = new StreamWriter(Path.Combine(saveTo, wrapper.Key), false, Encoding.UTF8))
+                        {
+                            textWriter.Write(wrapper.Value);
+                            textWriter.Flush();
+                        }
+                    }
+                }
             }
 
             public static void GenCPPWrap(string saveTo)
@@ -71,6 +162,7 @@ namespace PuertsIl2cpp.Editor
                 var types = from assembly in AppDomain.CurrentDomain.GetAssemblies()
                             // where assembly.FullName.Contains("puerts") || assembly.FullName.Contains("Assembly-CSharp") || assembly.FullName.Contains("Unity")
                             where !(assembly.ManifestModule is System.Reflection.Emit.ModuleBuilder)
+                            // where !IsAssemblyExcluded(Path.GetFileName(assembly.Location))
                             from type in assembly.GetTypes()
                             where type.IsPublic
                             select type;
@@ -131,7 +223,7 @@ namespace PuertsIl2cpp.Editor
                 var bridgeInfos = delegateInvokes
                     .Select(m => new SignatureInfo
                     {
-                        Signature = PuertsIl2cpp.TypeUtils.GetMethodSignature(m, true),
+                        Signature = PuertsIl2cpp.TypeUtils.GetMethodSignature(m, null, true),
                         CsName = m.ToString(),
                         ReturnSignature = PuertsIl2cpp.TypeUtils.GetTypeSignature(m.ReturnType),
                         ThisSignature = null,
@@ -145,7 +237,7 @@ namespace PuertsIl2cpp.Editor
                     .Select(m  => { 
                         var isExtensionMethod = m.IsDefined(typeof(ExtensionAttribute));
                         return new SignatureInfo {
-                            Signature = PuertsIl2cpp.TypeUtils.GetMethodSignature(m, false, isExtensionMethod),
+                            Signature = PuertsIl2cpp.TypeUtils.GetMethodSignature(m, null, false, isExtensionMethod),
                             CsName = m.ToString(),
                             ReturnSignature = PuertsIl2cpp.TypeUtils.GetTypeSignature(m.ReturnType),
                             ThisSignature = PuertsIl2cpp.TypeUtils.GetThisSignature(m, isExtensionMethod),

--- a/unity/Assets/core/upm/Editor/Src/Generator/IL2Cpp/UnityMenu.cs
+++ b/unity/Assets/core/upm/Editor/Src/Generator/IL2Cpp/UnityMenu.cs
@@ -39,6 +39,19 @@ namespace PuertsIl2cpp.Editor
                 AssetDatabase.Refresh();
             }
 
+            [MenuItem(PUERTS_MENU_PREFIX + "/Generate MethodWrapper.cs", false, 1)]
+            public static void GenerateMethodWrappers()
+            {
+                var start = DateTime.Now;
+                var saveTo = Puerts.Configure.GetCodeOutputDirectory();
+                
+                
+                Directory.CreateDirectory(saveTo);
+                FileExporter.GenMethodWithDefaultValue(saveTo);
+                Debug.Log("finished! use " + (DateTime.Now - start).TotalMilliseconds + " ms");
+                AssetDatabase.Refresh();
+            }
+
             [MenuItem(PUERTS_MENU_PREFIX + "/Generate ExtensionMethodInfos_Gen.cs", false, 1)]
             public static void GenerateExtensionMethodInfos()
             {

--- a/unity/Assets/core/upm/Editor/Src/Generator/Utils.cs
+++ b/unity/Assets/core/upm/Editor/Src/Generator/Utils.cs
@@ -60,6 +60,7 @@ namespace Puerts.Editor
 
             public static bool isBlittableType(Type type)
             {
+                
                 if (type.IsValueType)
                 {
                     bool ret;

--- a/unity/Assets/core/upm/Plugins/puerts_il2cpp/Puerts_il2cpp.cpp
+++ b/unity/Assets/core/upm/Plugins/puerts_il2cpp/Puerts_il2cpp.cpp
@@ -188,7 +188,7 @@ static void MethodCallback(pesapi_callback_info info) {
             }
             ++wrapDatas;
         }
-        pesapi_throw_by_string(info, "invalid arguments"); 
+        pesapi_throw_by_string(info, "invalid arguments for method"); 
     } 
     catch (Il2CppExceptionWrapper& exception)
     {
@@ -295,7 +295,7 @@ static void* CtorCallback(pesapi_callback_info info)
             ++wrapDatas;
         }
         
-        pesapi_throw_by_string(info, "invalid arguments");
+        pesapi_throw_by_string(info, "invalid arguments for constructor");
         
     } 
     catch (Il2CppExceptionWrapper& exception)

--- a/unity/Assets/core/upm/Runtime/Resources/puerts/log.mjs
+++ b/unity/Assets/core/upm/Runtime/Resources/puerts/log.mjs
@@ -16,7 +16,8 @@ if (UnityEngine_Debug) {
     function toString(args) {
         return Array.prototype.map.call(args, x => {
             try {
-                return x instanceof Error ? x.stack : x + '';
+                const ret = x instanceof Error ? x.stack : x + '';
+                return ret;
             } catch (err) {
                 return err;
             }

--- a/unity/Assets/core/upm/Runtime/Src/IL2Cpp/JsEnv.cs
+++ b/unity/Assets/core/upm/Runtime/Src/IL2Cpp/JsEnv.cs
@@ -81,7 +81,7 @@ namespace Puerts
                         const debugpathRef = [], contentRef = [];
                         const originSp = specifier;
                         
-                        if (specifier = loader.Resolve(specifier, debugpathRef)) {
+                        if (specifier = loader.Resolve(specifier)) {
                             loader.ReadFile(specifier, contentRef);
                             return contentRef[0];
                         } else {

--- a/unity/Assets/core/upm/Runtime/Src/IL2Cpp/TypeUtils.cs
+++ b/unity/Assets/core/upm/Runtime/Src/IL2Cpp/TypeUtils.cs
@@ -240,7 +240,7 @@ namespace PuertsIl2cpp
             }
             return "";
         }
-        public static string GetMethodSignature(MethodBase methodBase, bool isDelegateInvoke = false, bool isExtensionMethod = false)
+        public static string GetMethodSignature(MethodBase methodBase, ParameterInfo[] parameterInfos = null, bool isDelegateInvoke = false, bool isExtensionMethod = false)
         {
             string signature = "";
             if (methodBase is ConstructorInfo)
@@ -257,7 +257,7 @@ namespace PuertsIl2cpp
                 var methodInfo = methodBase as MethodInfo;
                 signature += GetTypeSignature(methodInfo.ReturnType);
                 if (!methodInfo.IsStatic && !isDelegateInvoke) signature += methodBase.DeclaringType == typeof(object) ? "T" : "t";
-                var parameterInfos = methodInfo.GetParameters();
+                if (parameterInfos == null) parameterInfos = methodInfo.GetParameters();
                 for (int i = 0; i < parameterInfos.Length; ++i)
                 {
                     if (i == 0 && isExtensionMethod)

--- a/unity/test/Src/Cases/EvalTest.cs
+++ b/unity/test/Src/Cases/EvalTest.cs
@@ -20,7 +20,7 @@ namespace Puerts.UnitTest
                 jsEnv.Eval(@"
                     var obj = {}; obj.func();
                 ");
-            });
+            }, "");
         }
         [Test]
         public void ESModuleNotFound()

--- a/unity/test/Src/Cases/GenericTest.cs
+++ b/unity/test/Src/Cases/GenericTest.cs
@@ -78,7 +78,7 @@ namespace Puerts.UnitTest
                         let res = CS.Puerts.UnitTest.GenericTestHelper.testListRange(ls,2);
                     })()
                 ");
-            });
+            }, "");
         }
 
         [Test]

--- a/unity/test/Src/Cases/OptionalParametersTest.cs
+++ b/unity/test/Src/Cases/OptionalParametersTest.cs
@@ -1,0 +1,271 @@
+using NUnit.Framework;
+
+namespace Puerts.UnitTest
+{
+    [UnityEngine.Scripting.Preserve]
+    public class OptionalParametersClass
+    {
+        [UnityEngine.Scripting.Preserve]
+        public int Test(int i = 0, int j = 1, int k = 2)
+        {
+            return i * 100 + j * 10 + k;
+        }
+
+        [UnityEngine.Scripting.Preserve]
+        public int Test(string i, int j = 1, int k = 2)
+        {
+            return j * 10 + k;
+        }
+
+        [UnityEngine.Scripting.Preserve]
+        public int Test2(string i)
+        {
+            return 0;
+        }
+
+        [UnityEngine.Scripting.Preserve]
+        public int Test2(string i, int j)
+        {
+            return j;
+        }
+
+        [UnityEngine.Scripting.Preserve]
+        public int Test2(string i, int j, params bool[] k)
+        {
+            return -1;
+        }
+
+        [UnityEngine.Scripting.Preserve]
+        public int Test3(string i, int b)
+        {
+            return 0;
+        }
+
+        [UnityEngine.Scripting.Preserve]
+        public int Test4(string i, int b, int c = 0, int d = 1)
+        {
+            return 0;
+        }
+
+        [UnityEngine.Scripting.Preserve]
+        public int Test5(string i, int j, params bool[] k)
+        {
+            return -1;
+        }
+        [UnityEngine.Scripting.Preserve]
+        public int Test6(int d, int i = 1, params string[] strs)
+        {
+            return i + d;
+        }
+        [UnityEngine.Scripting.Preserve]
+        public string TestFilter(string str)
+        {
+            return str + " hello";
+        }
+    }
+
+    [TestFixture]
+    public class OptionalParametersTest
+    {
+        [Test]
+        public void Test1()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test(1,3);
+                })()
+           ");
+            Assert.AreEqual(132, ret);
+            
+        }
+        [Test]
+        public void Test2()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test('1',3);
+                })()
+           ");
+            Assert.AreEqual(32, ret);
+            
+        }
+        [Test]
+        public void Test3()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test('1');
+                })()
+           ");
+            Assert.AreEqual(12, ret);
+            
+        }
+        [Test]
+        public void Test4()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test(6,6,6);
+                })()
+           ");
+            Assert.AreEqual(666, ret);
+            
+        }
+
+        [Test]
+        public void Test5()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test2('1',100);
+                })()
+           ");
+            Assert.AreEqual(100, ret);
+            
+        }
+
+        [Test]
+        public void Test6()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test2('1');
+                })()
+           ");
+            Assert.AreEqual(0, ret);
+            
+        }
+
+        [Test]
+        public void Test7()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test5('1', 1, false,false,false);
+                })()
+           ");
+            Assert.AreEqual(-1, ret);
+            
+        }
+
+        [Test]
+        public void Test8()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.Test5('1', 1, false);
+                })()
+           ");
+            Assert.AreEqual(-1, ret);
+            
+        }
+
+        [Test] 
+        public void Test9()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    let ret = 0;                
+                    try{temp.Test3('1');}catch(e){ret = 1;}
+                    return ret;
+                })()
+           ");
+            Assert.AreEqual(1, ret);
+            
+        }
+
+        [Test]
+        public void Test10()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    let ret = 0;                
+                    try{temp.Test3('1',1);}catch(e){ret = 1;}
+                    return ret;
+                })()
+           ");
+            Assert.AreEqual(0, ret);
+            
+        }
+
+        [Test]
+        public void Test11()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    let ret = 0;                
+                    try{temp.Test4('1');}catch(e){ if (e.message.indexOf('invalid') != -1) ret = 1; }
+                    return ret;
+                })()
+           ");
+            Assert.AreEqual(1, ret);
+            
+        }
+
+        [Test]
+        public void Test12()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    let ret = 0;                
+                    try{temp.Test4('1',1);}catch(e){ret = 1;}
+                    return ret;
+                })()
+           ");
+            Assert.AreEqual(0, ret);
+            
+        }
+
+        [Test]
+        public void Test13()
+        {
+            var env = UnitTestEnv.GetEnv();
+            int ret = env.Eval<int>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();            
+                    let ret = temp.Test6(1);
+                    return ret;
+                })()
+           ");
+            Assert.AreEqual(2, ret);
+            
+        }
+        [Test]
+        public void Test14()
+        {
+            var env = UnitTestEnv.GetEnv();
+            string ret = env.Eval<string>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.TestFilter('world');
+                })()
+           ");
+            Assert.AreEqual("world hello", ret);
+            
+        }
+    }
+}

--- a/unity/test/Src/TestFramework/Src/Attributes.cs
+++ b/unity/test/Src/TestFramework/Src/Attributes.cs
@@ -31,7 +31,7 @@ namespace NUnit {
         }
         
         public class Assert {
-            public static void Catch(Action action, string message = "") 
+            public static void Catch(Action action, string message) 
             {
                 try 
                 {

--- a/unity/test/unity/Assets/Editor/ExamplesCfg.cs
+++ b/unity/test/unity/Assets/Editor/ExamplesCfg.cs
@@ -1,0 +1,50 @@
+/*
+ * Tencent is pleased to support the open source community by making InjectFix available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company.  All rights reserved.
+ * InjectFix is licensed under the MIT License, except for the third-party components listed in the file 'LICENSE' which may be subject to their corresponding license terms. 
+ * This file is subject to the terms and conditions defined in file 'LICENSE', which is part of this source code package.
+ */
+
+using System.Collections.Generic;
+using Puerts;
+using System;
+using UnityEngine;
+
+//1、配置类必须打[Configure]标签
+//2、必须放Editor目录
+[Configure]
+public class ExamplesCfg
+{
+    [Binding]
+    static IEnumerable<Type> Bindings
+    {
+        get
+        {
+            return new List<Type>()
+            {
+                typeof(Puerts.UnitTest.OptionalParametersClass),
+            };
+        }
+    }
+    
+    [Filter]
+    static bool FilterMethods(System.Reflection.MemberInfo mb)
+    {
+        // 排除 MonoBehaviour.runInEditMode, 在 Editor 环境下可用发布后不存在
+        if (mb.DeclaringType == typeof(MonoBehaviour) && mb.Name == "runInEditMode") {
+            return true;
+        }
+        if (mb.DeclaringType == typeof(Type) && (mb.Name == "MakeGenericSignatureType" || mb.Name == "IsCollectible")) {
+            return true;
+        }
+        if (mb.DeclaringType == typeof(System.IO.File)) {
+            if (mb.Name == "SetAccessControl" || mb.Name == "GetAccessControl") {
+                return true;
+
+            } else if (mb.Name == "Create") {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/unity/test/unity/Assets/Editor/ExamplesCfg.cs.meta
+++ b/unity/test/unity/Assets/Editor/ExamplesCfg.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 116530c30a88c3d48a97dc35900790de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/test/unity/Assets/Scripts/Tester.cs
+++ b/unity/test/unity/Assets/Scripts/Tester.cs
@@ -16,7 +16,6 @@ public class Tester : MonoBehaviour {
     public bool IsTesting = false;
 
     void Start() {
-
         string MockConsoleContent = "";
         IsTesting = true;
 
@@ -40,6 +39,7 @@ public class Tester : MonoBehaviour {
     private IEnumerator RunTest(Action<string> OnSuccess, Action<string, Exception> OnFail)
     {
         UnityEngine.Debug.Log("Start RunTest");
+
         var types = from assembly in AppDomain.CurrentDomain.GetAssemblies()
                     // where !(assembly.ManifestModule is System.Reflection.Emit.ModuleBuilder)
                     from type in assembly.GetTypes()


### PR DESCRIPTION
1. 因为涉及C#生成，和旧版wrapper一样会遇到一个问题：在不同的unity版本下会有各种不同的接口无法生成。在我们这维护一个排除列表不是一件明智的事情。因此，这个feature不是像cppwrapper一样全量生成，而是读取BindingAttribute来生成默认值wrapper。因此不生成的类无法进行默认值调用
    > 但在开发过程中发现，如果把这些无法调用的接口排除，cppwrapper能瘦身20%
3. cppwrapper有一处改动：checkJSArgument为false时，如果参数数量不匹配也能直接调用，但IL2CPP调用时会将缺的参数填上0（即Type的默认值）。因此在checkJSArguments为false时，改为还是会判断一次参数数量。