### PR TITLE
[unity] v2 - bug修复、用例添加

### DIFF
--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/cppwrapper.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/cppwrapper.tpl.mjs
@@ -340,7 +340,7 @@ function genFuncWrapper(wrapperInfo) {
     return t`
 // ${wrapperInfo.CsName}
 static bool w_${wrapperInfo.Signature}(void* method, MethodPointer methodPointer, const v8::FunctionCallbackInfo<v8::Value>& info, bool checkJSArgument, void** typeInfos) {
-    // PLog("Running w_${wrapperInfo.Signature}");
+    //PLog("Running w_${wrapperInfo.Signature}");
     
     ${CODE_SNIPPETS.declareTypeInfo(wrapperInfo)}
 

--- a/unity/Assets/core/upm/Runtime/Resources/puerts/init_il2cpp.mjs
+++ b/unity/Assets/core/upm/Runtime/Resources/puerts/init_il2cpp.mjs
@@ -60,7 +60,6 @@ puer.getGenericMethod = function(csType, methodName, ...genericArgs) {
         throw new Error('the class must be a constructor');
     }
     let members = csType.GetMember(methodName, MemberTypes_Method, GET_MEMBER_FLAGS);
-    let typeof_System_Type = puer.$typeof(CS.System.Type)
     let overloadFunctions = [];
     for (let i = 0; i < members.Length; i++) {
         let method = members.GetValue(i)
@@ -115,7 +114,7 @@ puer.getGenericMethod = function(csType, methodName, ...genericArgs) {
                 } else if (jsValType === "bigint") {
                     argsCsArr.set_ItemBigInt(i, val, needArgTypeCode[i])
                 } else {
-                    argsCsArr.set_Item(val, i)
+                    argsCsArr.set_Item(i, val)
                 }
             }
             return argsCsArr;

--- a/unity/native_src_il2cpp/Src/Puerts.cpp
+++ b/unity/native_src_il2cpp/Src/Puerts.cpp
@@ -347,7 +347,7 @@ struct RestArguments
     static void* PackString(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* typeId, int start)
     {
         auto isolate = context->GetIsolate();
-        void* ret = NewArray(typeId, info.Length() - start);
+        void* ret = NewArray(typeId, info.Length() - start > 0 ? info.Length() - start : 0);
         for(int i = start; i < info.Length();++i)
         {
             v8::String::Utf8Value t(isolate, info[i]);

--- a/unity/test/Src/Cases/GenericTest.cs
+++ b/unity/test/Src/Cases/GenericTest.cs
@@ -135,8 +135,11 @@ namespace Puerts.UnitTest
                         return func('hello');
                     })();
                 ");
-                
+#if EXPERIMENTAL_IL2CPP_PUERTS
+            }, "'System.String' cannot be converted to type 'System.Int32'");
+#else 
             }, "invalid arguments to StaticGenericMethod");
+#endif
         }
 
         [Test]

--- a/unity/test/Src/Cases/OptionalParametersTest.cs
+++ b/unity/test/Src/Cases/OptionalParametersTest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace Puerts.UnitTest
@@ -10,19 +12,16 @@ namespace Puerts.UnitTest
 
         [UnityEngine.Scripting.Preserve]
         public OptionalParametersClass() {
-            UnityEngine.Debug.Log("Constructor1");
         }
 
         [UnityEngine.Scripting.Preserve]
         public OptionalParametersClass(int _c, int _a = 1, int _b = 2) {
-            UnityEngine.Debug.Log("Constructor2");
             a = _a * 1000;
             b = _b * 100;
         }
 
         [UnityEngine.Scripting.Preserve]
         public OptionalParametersClass(string _c, int _a = 1, int _b = 2) {
-            UnityEngine.Debug.Log("Constructor3");
             a = _a * 100;
             b = _b * 10;
         }
@@ -90,6 +89,16 @@ namespace Puerts.UnitTest
         public int Test6(int d, int i = 1, params string[] strs)
         {
             return i + d;
+        }
+        [UnityEngine.Scripting.Preserve]
+        public bool TestOptClass(List<string> list = default(List<string>))
+        {
+            return list == null;
+        }
+        [UnityEngine.Scripting.Preserve]
+        public double TestOptStruct(TimeSpan ts = default(TimeSpan))
+        {
+            return ts.TotalSeconds;
         }
         [UnityEngine.Scripting.Preserve]
         public string TestFilter(string str)
@@ -300,6 +309,31 @@ namespace Puerts.UnitTest
            ");
             Assert.AreEqual("world hello", ret);
             
+        }
+        [Test]
+        public void InstanceMethodTest15()
+        {
+            var env = UnitTestEnv.GetEnv();
+            bool ret = env.Eval<bool>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.TestOptClass();
+                })()
+           ");
+            Assert.True(ret);
+            
+        }
+        [Test]
+        public void InstanceMethodTest16()
+        {
+            var env = UnitTestEnv.GetEnv();
+            double ret = env.Eval<double>(@"
+                (function() {
+                    let temp = new CS.Puerts.UnitTest.OptionalParametersClass();
+                    return temp.TestOptStruct();
+                })()
+           ");
+            Assert.AreEqual(0, ret);            
         }
 
         [Test]

--- a/unity/test/Src/TestFramework/Src/Attributes.cs
+++ b/unity/test/Src/TestFramework/Src/Attributes.cs
@@ -41,9 +41,11 @@ namespace NUnit {
                 {
                     if (message.Length > 0 && !e.Message.Contains(message))
                     {
-                        throw new Exception($"expect a error with {message} but got {e.Message}");
+                        throw new Exception($"expect an error with {message} but got {e.Message}");
                     }
+                    return;
                 }
+                throw new Exception($"expect an error but tbe code did not thrown any");
             }
             public static void Contains(string a, string b)
             {

--- a/unity/test/unity/Assets/Scripts/Tester.cs
+++ b/unity/test/unity/Assets/Scripts/Tester.cs
@@ -58,6 +58,7 @@ public class Tester : MonoBehaviour {
                     yield return null;
                     if (IsTesting && ca.GetType() == typeof(TestAttribute)) 
                     {
+                        // if (method.Name != "StaticGenericMethodInvalidCallArguments") continue;
                         try 
                         {
                             method.Invoke(testInstance, null);


### PR DESCRIPTION
修复以下问题：
1. genericMethod 传入参数时key value 传反了
2. params参数前如果有可选参数且调用时未传入该可选参数，会导致创建负数长度的数组

添加测试用例：
1. 可选参数是引用类型
2. 可选参数是struct