### PR TITLE
修复 V8Utils.h Cannot find file 'NameTypes.h' 报错

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Public/V8Utils.h
+++ b/unreal/Puerts/Source/JsEnv/Public/V8Utils.h
@@ -19,7 +19,6 @@
 #pragma warning(pop)
 
 #include "DataTransfer.h"
-#include "NameTypes.h"
 
 namespace puerts
 {

--- a/unreal/Puerts/Source/Puerts/Private/PuertsSetting.cpp
+++ b/unreal/Puerts/Source/Puerts/Private/PuertsSetting.cpp
@@ -7,3 +7,8 @@
  */
 
 #include "PuertsSetting.h"
+
+UPuertsSetting::UPuertsSetting()
+{
+    RootPath.Path = TEXT("../../Content/JavaScript");
+}

--- a/unreal/Puerts/Source/Puerts/Private/PuertsSetting.h
+++ b/unreal/Puerts/Source/Puerts/Private/PuertsSetting.h
@@ -17,6 +17,9 @@ class UPuertsSetting : public UObject
 {
     GENERATED_BODY()
 public:
+    UPROPERTY(config, EditAnywhere, Category = "Engine Class Extends Mode", meta = (Tooltip = "JavaScript Source Code Root Path", DisplayName = "JavaScript Root"))
+    FDirectoryPath RootPath;
+
     UPROPERTY(config, EditAnywhere, Category = "Engine Class Extends Mode", meta = (DisplayName = "Enable", defaultValue = false))
     bool AutoModeEnable = false;
 
@@ -33,15 +36,15 @@ public:
     bool WaitDebugger = false;
 
     UPROPERTY(config, EditAnywhere, Category = "Engine Class Extends Mode",
-        meta = (DisplayName = "Wait Debugger Timeout", defaultValue = 0))
+              meta = (DisplayName = "Wait Debugger Timeout", defaultValue = 0))
     double WaitDebuggerTimeout = 0;
 
     UPROPERTY(config, EditAnywhere, Category = "Engine Class Extends Mode",
-        meta = (DisplayName = "Number of JavaScript Env", defaultValue = 1))
+              meta = (DisplayName = "Number of JavaScript Env", defaultValue = 1))
     int32 NumberOfJsEnv = 1;
 
     UPROPERTY(config, EditAnywhere, Category = "Engine Class Extends Mode",
-        meta = (DisplayName = "Disable TypeScript Watch", defaultValue = false))
+              meta = (DisplayName = "Disable TypeScript Watch", defaultValue = false))
     bool WatchDisable = false;
 
     UPROPERTY(config, EditAnywhere, Category = "Declaration Generator", meta = (DisplayName = "D.ts Ignore Class Name List"))
@@ -49,4 +52,7 @@ public:
 
     UPROPERTY(config, EditAnywhere, Category = "Declaration Generator", meta = (DisplayName = "D.ts Ignore Struct Name List"))
     TArray<FString> IgnoreStructListOnDTS;
+
+public: 
+    UPuertsSetting();
 };


### PR DESCRIPTION
V8Utils.h #include "CoreMinimal.h"，包含 #include "UObject/NameTypes.h"，所以这里删除这行代码修复报错