### PR TITLE
[Unreal]修复一些编译错误

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -27,7 +27,7 @@
 #include "GenDTSCommands.h"
 #include "Framework/Notifications/NotificationManager.h"
 #include "Widgets/Notifications/SNotificationList.h"
-//#include "Misc/MessageDialog.h"
+// #include "Misc/MessageDialog.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Engine/UserDefinedStruct.h"
 #include "Engine/UserDefinedEnum.h"
@@ -592,7 +592,7 @@ void FTypeScriptDeclarationGenerator::LoadAllWidgetBlueprint(FName InSearchPath,
     BPFilter.PackagePaths.Add(PackagePath);
     BPFilter.bRecursivePaths = true;
     BPFilter.bRecursiveClasses = true;
-#if ENGINE_MAJOR_VERSION >= 5
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 0
     BPFilter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
     BPFilter.ClassPaths.Add(UUserDefinedEnum::StaticClass()->GetClassPathName());
     BPFilter.ClassPaths.Add(UUserDefinedStruct::StaticClass()->GetClassPathName());

--- a/unreal/Puerts/Source/Puerts/Private/PuertsModule.cpp
+++ b/unreal/Puerts/Source/Puerts/Private/PuertsModule.cpp
@@ -205,7 +205,7 @@ public:
                 JsEnvGroup->SetJsEnvSelector(Selector);
             }
 
-            //这种不支持等待
+            // 这种不支持等待
             if (Settings.WaitDebugger)
             {
                 UE_LOG(PuertsModule, Warning, TEXT("Do not support WaitDebugger in Group Mode!"));
@@ -363,7 +363,7 @@ void FPuertsModule::RegisterSettings()
     const FString PuertsConfigIniPath =
         FConfigCacheIni::NormalizeConfigIniPath(FPaths::SourceConfigDir().Append(TEXT("DefaultPuerts.ini")));
 #else
-    const FString PuertsConfigIniPath = FFPaths::SourceConfigDir().Append(TEXT("DefaultPuerts.ini"));
+    const FString PuertsConfigIniPath = FPaths::SourceConfigDir().Append(TEXT("DefaultPuerts.ini"));
 #endif
     if (GConfig->DoesSectionExist(SectionName, PuertsConfigIniPath))
     {


### PR DESCRIPTION
1. 修复FPaths编写错误导致编译不通过的问题;
2. 修复UE5.0.x下一处编译错误的问题;
3. 对相应文件作clang-format;