### PR TITLE
[UE] fix: compatible with bundlers. 

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -25,6 +25,7 @@ var global = global || (function () { return this; }());
             return classWrapers[name];
         }
     });
+    Object.defineProperty(UE, "__esModule", {value: true});
     
     const TNAMESPACE = 0;
     const TENUM = 1
@@ -83,6 +84,7 @@ var global = global || (function () { return this; }());
             return classWrapers[name];
         }
     });
+    Object.defineProperty(CPP, "__esModule", {value: true});
     
     puerts.registerBuildinModule('cpp', CPP);
     


### PR DESCRIPTION
Fixed #1252 
大多数JS打包器为了ESM和CommonJS的兼容，引入了助手工具，在运行时判断"__esModule"的值，进而决定是否继续遍历获取模块的属性。"ue"和"cpp"模块中的loadType方法是延迟加载的思路，和这些助手函数有冲突，参考https://github.com/rollup/rollup/pull/2954
        引入"__esModule = true"，可解决这个问题。在Windows下，UE5.0.3，打包工具为tsup的环境下，测试通过。不过，"__esModule"只是诸多打包器的惯用方式，并非语言官方规范中的属性。