### PR TITLE
增加头文件生成的依赖引入

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Public/TypeScriptDeclarationGenerator.h
+++ b/unreal/Puerts/Source/DeclarationGenerator/Public/TypeScriptDeclarationGenerator.h
@@ -64,6 +64,7 @@ struct DECLARATIONGENERATOR_API FTypeScriptDeclarationGenerator
         FString FileVersionString;
         bool IsExist;
         bool Changed;
+        bool IsAssociation;
     };
 
     TMap<FName, BlueprintTypeDeclInfo> BlueprintTypeDeclInfoCache;
@@ -71,6 +72,8 @@ struct DECLARATIONGENERATOR_API FTypeScriptDeclarationGenerator
     TArray<FAssetData> AssetList;
 
     bool RefFromOuter = false;
+
+    bool BeginGenAssetData = false;
 
     const FString& GetNamespace(UObject* Obj);
 
@@ -84,9 +87,9 @@ struct DECLARATIONGENERATOR_API FTypeScriptDeclarationGenerator
 
     void WriteOutput(UObject* Obj, const FStringBuffer& Buff);
 
-    void RestoreBlueprintTypeDeclInfos();
+    void RestoreBlueprintTypeDeclInfos(bool InGenFull);
 
-    void RestoreBlueprintTypeDeclInfos(const FString& FileContent);
+    void RestoreBlueprintTypeDeclInfos(const FString& FileContent, bool InGenFull);
 
     void LoadAllWidgetBlueprint(FName InSearchPath, bool InGenFull);
 


### PR DESCRIPTION
修复 #1184 ，引用进来的、不在生成目录下的蓝图，使用特殊标记ASSOCIATION标记。不检查变更，只在Full模式下重新生成