### PR TITLE
Update DeclarationGenerator.cpp

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -1394,13 +1394,15 @@ private:
         {
             UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Window");
             {
-                FToolMenuSection& Section = Menu->FindOrAddSection("WindowLayout");
+                FToolMenuSection& Section = Menu->FindOrAddSection("User");
+                if (&Section == nullptr) { Section = Menu->FindOrAddSection("WindowLayout"); }
                 Section.AddMenuEntryWithCommandList(FGenDTSCommands::Get().PluginAction, PluginCommands);
             }
         }
 
         {
-            UToolMenu* ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar.PlayToolBar");
+            UToolMenu* ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar.User");
+            if (ToolbarMenu == nullptr) { ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar.PlayToolBar"); }
             {
                 FToolMenuSection& Section = ToolbarMenu->FindOrAddSection("PluginTools");
                 {

--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -1395,14 +1395,22 @@ private:
             UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Window");
             {
                 FToolMenuSection& Section = Menu->FindOrAddSection("User");
-                if (&Section == nullptr) { Section = Menu->FindOrAddSection("WindowLayout"); }
-                Section.AddMenuEntryWithCommandList(FGenDTSCommands::Get().PluginAction, PluginCommands);
+            	if (&Section == nullptr)
+            	{
+                	Section = Menu->FindOrAddSection("WindowLayout");
+            	}
+            	{
+                	Section.AddMenuEntryWithCommandList(FGenDTSCommands::Get().PluginAction, PluginCommands);
+            	}
             }
         }
 
         {
             UToolMenu* ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar.User");
-            if (ToolbarMenu == nullptr) { ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar.PlayToolBar"); }
+            if (ToolbarMenu == nullptr)
+            {
+                ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.LevelEditorToolBar.PlayToolBar");
+            }
             {
                 FToolMenuSection& Section = ToolbarMenu->FindOrAddSection("PluginTools");
                 {


### PR DESCRIPTION
Unreal 5+ added "User" sections to add new toolbar and menu items. This potentially solves PuerTS buttons to overlap with other plugins controls. As a precaution, If this new section is not found the old code keep running instead.