### PR TITLE
[Unreal]Fix some WasmCore compile error

### DIFF
--- a/unreal/Puerts/Source/WasmCore/Public/WasmBindingTemplate.hpp
+++ b/unreal/Puerts/Source/WasmCore/Public/WasmBindingTemplate.hpp
@@ -82,12 +82,13 @@ static_assert(!wasm_is_simple_type<FVector>::value, "");
 template <typename T>
 struct _wasm_is_complex_type
 {
+    // TODO Is it necessary to consider trivially copyable class?
     //这里有点奇怪
     // 属性数量大于1的结构体当指针
     // 小于32的结构体当int32,小于64的结构体当int64,大于64的当指针
     // 我们判断不了属性数量，所以强制规定,结构体必须大于64
     static constexpr bool value =
-        !wasm_is_simple_type<T>::value && std::is_class<T>::value && std::is_trivially_copyable<T>::value && (sizeof(T) > 8);
+        !wasm_is_simple_type<T>::value && std::is_class<T>::value && (sizeof(T) > 8);
 };
 
 template <typename T>
@@ -109,8 +110,9 @@ template <typename T>
 struct wasm_is_support_pointer_type
 {
     using No_PTr = typename std::remove_pointer<T>::type;
+    // TODO UObject is a "complex_type", right?
     static constexpr bool value =
-        std::is_pointer<T>::value && !wasm_is_complex_type<No_PTr>::value && !wasm_is_simple_type<No_PTr>::value;
+        std::is_pointer<T>::value && !wasm_is_simple_type<No_PTr>::value && wasm_is_complex_type<No_PTr>::value;
 };
 
 template <typename... Args>


### PR DESCRIPTION
fix issue #1310 
- 修复wasm相关代码无法编译的问题，修改了一些判断条件，但不确定是否会影响新增的wasm的功能。
在Windows，UE5.0.3，编辑器上，通过Demo的QuickStart测试，以及https://github.com/Tencent/puerts/blob/4b80213fda0764c5ab86f3075fa3aebb0d5dfc2b/doc/unreal/zhcn/wasm.md 当中所述的JS函数测试(测试结果：编辑器打印出 ffffffffffffffffffffffff, 3.515625 )，但并未测试在Wasm中UObject返回值的情况(因测试用例中似乎没有覆盖到)。
- 对WasmBindingTemplate.hpp作clang-format