### PR TITLE
[unreal] feat: 完善 esm 模块读取支持

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/modular.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/modular.js
@@ -129,7 +129,7 @@ var global = global || (function () { return this; }());
                     isESM = packageConfigure.type === "module"
                     let url = packageConfigure.main || "index.js";
                     if (isESM) {
-                        url = packageConfigure.exports && packageConfigure.exports["."] && packageConfigure.exports["."]["default"] && packageConfigure.exports["."]["default"]["require"]
+                        url = packageConfigure.exports && packageConfigure.exports["."] && ((packageConfigure.exports["."]["default"] && packageConfigure.exports["."]["default"]["require"]) || (packageConfigure.exports["."]["require"] && packageConfigure.exports["."]["require"]["default"]))
                         if (!url) {
                             throw new Error("can not require a esm in cjs module!");
                         }


### PR DESCRIPTION
https://www.npmjs.com/package/copy-anything
https://www.npmjs.com/package/is-what

最近用到了上面俩插件，发现在配置里 `require` 和 `default` 的嵌套关系是反的，添加一下支持，这俩插件的配置如下：

```
{
  "exports": {
    ".": {
      "require": {
        "types": "./dist/cjs/index.d.cts",
        "default": "./dist/cjs/index.cjs"
      },
      "import": {
        "types": "./dist/index.d.ts",
        "default": "./dist/index.js"
      }
    }
  }
}
```