### PR TITLE
[unreal] fix: 修复require某些esm模块失败的问题

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/modular.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/modular.js
@@ -129,7 +129,12 @@ var global = global || (function () { return this; }());
                     isESM = packageConfigure.type === "module"
                     let url = packageConfigure.main || "index.js";
                     if (isESM) {
-                        url = packageConfigure.exports && packageConfigure.exports["."] && ((packageConfigure.exports["."]["default"] && packageConfigure.exports["."]["default"]["require"]) || (packageConfigure.exports["."]["require"] && packageConfigure.exports["."]["require"]["default"]))
+                        let packageExports = packageConfigure.exports && packageConfigure.exports["."];
+                        if (packageExports)
+                            url =
+                                (packageExports["default"] && packageExports["default"]["require"]) ||
+                                (packageExports["require"] && packageExports["require"]["default"]) ||
+                                packageExports["require"];                        
                         if (!url) {
                             throw new Error("can not require a esm in cjs module!");
                         }


### PR DESCRIPTION
https://www.npmjs.com/package/@formulajs/formulajs
在require 此库时出现问题，其package.json中的exports是下面的样子：

```
  "exports": {
    ".": {
      "require": "./lib/cjs/index.cjs",
      "import": "./lib/esm/index.mjs"
    },
    "./package.json": "./package.json"
  },
```

参考pr https://github.com/Tencent/puerts/pull/1379 中的改法，又补充了下esm的处理