### PR TITLE
fix: fix import esm bug.

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/modular.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/modular.js
@@ -121,7 +121,11 @@ var global = global || (function () { return this; }());
             let sid = addModule(m);
             let script = loadModule(fullPath);
             isESM = isESM === true || fullPath.endsWith(".mjs")
-            if (fullPath.endsWith(".cjs")) isESM = false;
+            let cachedIsESM = isESM;
+            if (fullPath.endsWith(".cjs")) {
+                isESM = true;
+                cachedIsESM = false;
+            }
             if (fullPath.endsWith(".json")) {
                 let packageConfigure = JSON.parse(script);
                 
@@ -138,12 +142,14 @@ var global = global || (function () { return this; }());
                         if (!url) {
                             throw new Error("can not require a esm in cjs module!");
                         }
+                        isESM = cachedIsESM;
                     }
                     let fullDirInJs = (fullPath.indexOf('/') != -1) ? fullPath.substring(0, fullPath.lastIndexOf("/")) : fullPath.substring(0, fullPath.lastIndexOf("\\")).replace(/\\/g, '\\\\');
                     let tmpRequire = genRequire(fullDirInJs, isESM);
                     let r = tmpRequire(url);
                     tmpModuleStorage[sid] = undefined;
                     m.exports = r;
+                    isESM = cachedIsESM;
                 } else {
                     tmpModuleStorage[sid] = undefined;
                     m.exports = packageConfigure;


### PR DESCRIPTION
bug: 在tsc下，先导入第三方库(比如axios)，再导入自己的模块代码，编译后编辑器运行，则会引发找不到模块的错误;
原因是modular.js中的isESM变量没有适时恢复