### PR TITLE
修复RestoreBlueprintTypeDeclInfos读取的文件路径还是旧路径的问题

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -531,7 +531,7 @@ void FTypeScriptDeclarationGenerator::RestoreBlueprintTypeDeclInfos(bool InGenFu
 {
     FString FileContent;
     FFileHelper::LoadFileToString(
-        FileContent, *(IPluginManager::Get().FindPlugin("Puerts")->GetBaseDir() / TEXT("Typing/ue/ue_bp.d.ts")));
+        FileContent, *(FPaths::ProjectDir() / TEXT("Typing/ue/ue_bp.d.ts")));
     RestoreBlueprintTypeDeclInfos(FileContent, InGenFull);
 }
 

--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -530,8 +530,7 @@ void FTypeScriptDeclarationGenerator::WriteOutput(UObject* Obj, const FStringBuf
 void FTypeScriptDeclarationGenerator::RestoreBlueprintTypeDeclInfos(bool InGenFull)
 {
     FString FileContent;
-    FFileHelper::LoadFileToString(
-        FileContent, *(FPaths::ProjectDir() / TEXT("Typing/ue/ue_bp.d.ts")));
+    FFileHelper::LoadFileToString(FileContent, *(FPaths::ProjectDir() / TEXT("Typing/ue/ue_bp.d.ts")));
     RestoreBlueprintTypeDeclInfos(FileContent, InGenFull);
 }
 


### PR DESCRIPTION
修复#1446 更改为读取新的ue_bp.d.ts