### PR TITLE
[Unity]C#类型继承自嵌套类时, dts声明生成的父类名错误(重复的外层名称)

### DIFF
--- a/unity/Assets/core/upm/Editor/Src/Generator/DTS.cs
+++ b/unity/Assets/core/upm/Editor/Src/Generator/DTS.cs
@@ -418,13 +418,18 @@ namespace Puerts.Editor
                                 temp = temp.DeclaringType;
                             }
                             p.Reverse();
+                            string pstr = string.Join(".", p.ToArray());
+                            if (pstr.Length > 0 && result.BaseType.Name.StartsWith(pstr))
+                            {
+                                result.BaseType.Name = result.BaseType.Name.Substring(pstr.Length + 1);
+                            }
                             if (type.BaseType.Namespace != null)
                             {
-                                result.BaseType.Namespace = type.BaseType.Namespace + '.' + string.Join(".", p.ToArray());
+                                result.BaseType.Namespace = type.BaseType.Namespace + '.' + pstr;
                             }
                             else
                             {
-                                result.BaseType.Namespace = string.Join(".", p.ToArray());
+                                result.BaseType.Namespace = pstr;
                             }
                         }
                         if (type.BaseType.IsGenericType && type.BaseType.Namespace != null)


### PR DESCRIPTION
以下为示例C#类型:
```csharp
public class ClassA
{
    public abstract class Base<T>
    {

    }
    public class ChildA : Base<int>
    {
    }
    public class ChildB : Base<string>
    {
    }
}
```
它生成的dts声明
```typescript
namespace ClassA {
    class Base$1<T> extends System.Object
    {
        protected [__keep_incompatibility]: never;
    }
    class ChildA extends ClassA.ClassA.Base$1<number>
    {
        protected [__keep_incompatibility]: never;
        public constructor ()
    }
    class ChildB extends ClassA.ClassA.Base$1<string>
    {
        protected [__keep_incompatibility]: never;
        public constructor ()
    }
}
```