### PR TITLE
容器添加[Symbol.iterator]支持

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -274,8 +274,8 @@ var global = global || (function () { return this; }());
                 let index = 0;
                 let num = this.Num();
                 while (index < num) {
-                yield this.Get(index);
-                index++;
+                    yield this.Get(index);
+                    index++;
                 }
             }
         }

--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -268,20 +268,59 @@ var global = global || (function () { return this; }());
     function NewArray(t1) {
         t1 = translateType(t1);
 
-        return newContainer(0, t1);
+        var ret = newContainer(0, t1);
+        if (!("[Symbol.iterator]" in ret)) {
+            ret.constructor.prototype[Symbol.iterator] = function*() {
+                let index = 0;
+                let num = this.Num();
+                while (index < num) {
+                yield this.Get(index);
+                index++;
+                }
+            }
+        }
+        return ret;
     }
     
     function NewSet(t1) {
         t1 = translateType(t1);
         
-        return newContainer(1, t1);
+        var ret = newContainer(1, t1);
+        if (!("[Symbol.iterator]" in ret)) {
+            ret.constructor.prototype[Symbol.iterator] = function*() {
+                let index = 0;
+                let maxIndex = this.GetMaxIndex();
+                while (index < maxIndex) {
+                    if (this.IsValidIndex(index)) {
+                        yield this.Get(index);
+                    }
+                    index++;
+                }
+            }
+        }
+        return ret;
     }
     
     function NewMap(t1, t2) {
         t1 = translateType(t1);
         t2 = translateType(t2);
-        
-        return newContainer(2, t1, t2);
+
+        var ret = newContainer(2, t1, t2);
+        if (!("[Symbol.iterator]" in ret)) {
+            ret.constructor.prototype[Symbol.iterator] = function*() {
+                let index = 0;
+                let maxIndex = this.GetMaxIndex();
+                while (index < maxIndex) {
+                    if (this.IsValidIndex(index)) {
+                        let key = this.GetKey(index);
+                        let value = this.Get(key);
+                        yield [key, value];
+                    }
+                    index++;
+                }
+            }
+        }
+        return ret;
     }
     
     cache.BuiltinBool = 0;

--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -332,6 +332,11 @@ var global = global || (function () { return this; }());
     cache.BuiltinText = 6;
     cache.BuiltinName = 7;
     
+    // call once to inject iterators to constructor
+    NewArray(cache.BuiltinInt);
+    NewSet(cache.BuiltinInt);
+    NewMap(cache.BuiltinInt, cache.BuiltinInt);
+    
     cache.NewArray = NewArray;
     cache.NewSet = NewSet;
     cache.NewMap = NewMap;

--- a/unreal/Puerts/Typing/ue/puerts.d.ts
+++ b/unreal/Puerts/Typing/ue/puerts.d.ts
@@ -44,6 +44,7 @@ declare module "ue" {
         RemoveAt(Index: number): void;
         IsValidIndex(Index: number): boolean;
         Empty(): void;
+        [Symbol.iterator](): IterableIterator<T>;
     }
     
     interface TSet<T> {
@@ -58,6 +59,7 @@ declare module "ue" {
         GetMaxIndex(): number;  // TODO - GetMaxIndex的返回值是InvalidIndex，合理吗？（GetMaxIndex的解释应该是：最大合法index+1），当调用Empty，返回值为0
         IsValidIndex(Index: number): boolean;
         Empty(): void;
+        [Symbol.iterator](): IterableIterator<T>;
     }
     
     interface TMap<TKey, TValue> {
@@ -71,6 +73,7 @@ declare module "ue" {
         IsValidIndex(Index: number): boolean;
         GetKey(Index: number): TKey;            // TODO - 对于非法index，是否应该返回undefined
         Empty(): void;
+        [Symbol.iterator](): IterableIterator<[TKey, TValue]>;
     }
 
     interface TSharedPtr<T> {


### PR DESCRIPTION
更好的支持 `for(let ... of)`语法，以及更好的支持 JS容器与UE容器之间的交互。

一个简单的测试样例

```js
import * as UE from 'ue'

{
  console.log('iterateArr Test');
  const arr = UE.NewArray(UE.BuiltinInt);
  arr.Add(...[1, 2, 3, 4, 5, 6]);
  for (const i of arr) {
    console.log(i) // 1,2,3,4,5,6
  }

  console.log(...arr) // 1,2,3,4,5,6
  
  const jsArray = Array.from(arr);
  console.log("jsarray", jsArray) // jsarray, [1,2,3,4,5,6]
}

{
  console.log('iterateArr Set');
  const set = UE.NewSet(UE.BuiltinInt);
  for (let i = 0; i < 10; i++) {
    set.Add(i);
    set.Add(i);
    set.Add(i);
  }
  for (const i of set) {
    console.log(i)
  }
  console.log(...set) // 0,1,2,3,4...,9
  const jsArray = Array.from(set);
  console.log("js from set", jsArray) // js from set, [0,1,2,3,4,5,6,7,8,9]
}

{
  console.log('iterateArr Map');
  const map = UE.NewMap(UE.BuiltinInt, UE.BuiltinInt);
  for (let i = 0; i < 10; i++) {
    map.Add(i, 100 - i);
  }

  for (const [key,value] of map) {
    console.log(`map: ${key}: ${value}`) 
  }
  // output:
  // 0 100
  // 1 99
  // 2 98
  // ...
  // 9 91
}
```