### PR TITLE
[unity] commonjs情况下，loadType报错

### DIFF
--- a/unity/Assets/core/upm/Runtime/Resources/puerts/init_il2cpp.mjs
+++ b/unity/Assets/core/upm/Runtime/Resources/puerts/init_il2cpp.mjs
@@ -17,7 +17,7 @@ puer.loadType = function(nameOrCSType, ...genericArgs) {
         csType = jsEnv.GetTypeByString(nameOrCSType)
     }
     if (csType) {
-        if (genericArgs && csType.IsGenericTypeDefinition) {
+        if (genericArgs && genericArgs.length > 0 && csType.IsGenericTypeDefinition) {
             genericArgs = genericArgs.map(g => puer.$typeof(g));
             csType = csType.MakeGenericType(...genericArgs);
         }


### PR DESCRIPTION
 if (genericArgs), genericArgs为空数组时判断为True，进到MakeGenericType会报参数不对