### PR TITLE
[unreal] 修复 codegen .d.ts 函数参数列表可能重名的问题

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -898,6 +898,27 @@ bool FTypeScriptDeclarationGenerator::GenFunction(
     }
     OwnerBuffer << "(";
     PropertyMacro* ReturnValue = nullptr;
+
+    TSet<FString> NameDeDupSet{};
+    auto const DeDup = [&NameDeDupSet](FString const& Name)
+    {
+        if (!NameDeDupSet.Contains(Name))
+        {
+            NameDeDupSet.Add(Name);
+            return Name;
+        }
+
+        int Cnt = 1;
+        FString NewName = FString::Printf(TEXT("%s_%d"), *Name, Cnt);
+        while (NameDeDupSet.Contains(NewName))
+        {
+            Cnt++;
+            NewName = FString::Printf(TEXT("%s_%d"), *Name, Cnt);
+        }
+
+        return NewName;
+    };
+
     TArray<UObject*> RefTypes;
     TArray<FString> ParamDecls;
     bool First = true;
@@ -928,7 +949,7 @@ bool FTypeScriptDeclarationGenerator::GenFunction(
                     DefaultValuePtr = MetaMap->Find(MetadataCppDefaultValueKey);
                 }
 
-                TmpBuf << SafeParamName(Property->GetName());
+                TmpBuf << DeDup(SafeParamName(Property->GetName()));
                 if (DefaultValuePtr)
                 {
                     TmpBuf << "?";


### PR DESCRIPTION
处理函数参数名去重，避免 .d.ts 文件中参数名可能冲突的问题：

![image](https://github.com/Tencent/puerts/assets/6213647/8033cb06-738f-4a75-bac4-086c823d8e73)
