### PR TITLE
解决当extension methods默认参数有传参时，index读取不正确bug

### DIFF
--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/cppwrapper.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/cppwrapper.tpl.mjs
@@ -326,19 +326,19 @@ ${CODE_SNIPPETS.JSValToCSVal(signature, 'MaybeRet.ToLocalChecked()', 'ret')}
             const start = parseInt(JSName.match(/info\[(\d+)\]/)[1]);
             if (si in PrimitiveSignatureCppTypeMap) { 
                 return `    // JSValToCSVal primitive with default
-    ${PrimitiveSignatureCppTypeMap[si]} ${CSName} = OptionalParameter<${PrimitiveSignatureCppTypeMap[si]}>::GetPrimitive(context, info, method, wrapData->IsExtensionMethod ? ${start + 1} : ${start});
+    ${PrimitiveSignatureCppTypeMap[si]} ${CSName} = OptionalParameter<${PrimitiveSignatureCppTypeMap[si]}>::GetPrimitive(context, info, method, wrapData, ${start});
                 `
             } else if (si == 's') {
                 return `    // JSValToCSVal string  with default
-    void* ${CSName} = OptionalParameter<void*>::GetString(context, info, method, wrapData->IsExtensionMethod ? ${start + 1} : ${start});
+    void* ${CSName} = OptionalParameter<void*>::GetString(context, info, method, wrapData, ${start});
                 `
             } else if (si == 'o' || si == 'O' || si == 'a') {
                 return `    // JSValToCSVal ref  with default
-    void* ${CSName} = OptionalParameter<void*>::GetRefType(context, info, method, wrapData->IsExtensionMethod ? ${start + 1} : ${start}, TI${CSName});
+    void* ${CSName} = OptionalParameter<void*>::GetRefType(context, info, method, wrapData, ${start}, TI${CSName});
                 `
             } else if ((si.startsWith(sigs.StructPrefix) || si.startsWith(sigs.NullableStructPrefix)) && si.endsWith('_')) { 
                 return `    // JSValToCSVal valuetype  with default
-    ${si} ${CSName} = OptionalParameter<${si}>::GetValueType(context, info, method, wrapData->IsExtensionMethod ? ${start + 1} : ${start});
+    ${si} ${CSName} = OptionalParameter<${si}>::GetValueType(context, info, method, wrapData, ${start});
                 `
             } else {
                 return `    // JSValToCSVal unknow type with default

--- a/unity/native_src_il2cpp/Src/Puerts.cpp
+++ b/unity/native_src_il2cpp/Src/Puerts.cpp
@@ -569,7 +569,7 @@ struct RestArguments
 template <typename T>
 struct OptionalParameter
 {
-    static T GetPrimitive(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, int index)
+    static T GetPrimitive(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, puerts::WrapData* wrapData, int index)
     {
         if (index < info.Length())
         {
@@ -577,6 +577,7 @@ struct OptionalParameter
         }
         else
         {
+            if (wrapData->IsExtensionMethod) ++index;
             auto pret = (T*)GetDefaultValuePtr(methodInfo, index);
             if (pret) 
             {
@@ -586,7 +587,7 @@ struct OptionalParameter
         }
     }
     
-    static T GetValueType(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, int index)
+    static T GetValueType(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, puerts::WrapData* wrapData, int index)
     {
         if (index < info.Length())
         {
@@ -594,6 +595,7 @@ struct OptionalParameter
         }
         else
         {
+            if (wrapData->IsExtensionMethod) ++index;
             auto pret = (T*)GetDefaultValuePtr(methodInfo, index);
             if (pret) 
             {
@@ -605,7 +607,7 @@ struct OptionalParameter
         }
     }
     
-    static void* GetString(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, int index)
+    static void* GetString(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, puerts::WrapData* wrapData, int index)
     {
         if (index < info.Length())
         {
@@ -614,11 +616,12 @@ struct OptionalParameter
         }
         else
         {
+            if (wrapData->IsExtensionMethod) ++index;
             return GetDefaultValuePtr(methodInfo, index);
         }
     }
     
-    static void* GetRefType(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, int index, const void* typeId)
+    static void* GetRefType(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, const void* methodInfo, puerts::WrapData* wrapData, int index, const void* typeId)
     {
         if (index < info.Length())
         {
@@ -626,6 +629,7 @@ struct OptionalParameter
         }
         else
         {
+            if (wrapData->IsExtensionMethod) ++index;
             return GetDefaultValuePtr(methodInfo, index);
         }
     }


### PR DESCRIPTION
之前修改的c# extension 默认参数不传导致闪退问题，导致正常传参数时候，index被加了1，使得无法给有默认值的参数传值
https://github.com/Tencent/puerts/issues/1586