### PR TITLE
不必要的Reset导致内存泄露，Release传入的地址是null

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -2604,7 +2604,6 @@ bool FJsEnvImpl::ClearDelegate(v8::Isolate* Isolate, v8::Local<v8::Context>& Con
     if (Iter->second.Proxy.IsValid())
     {
         Iter->second.Proxy->JsFunction.Reset();
-        Iter->second.Proxy.Reset();
         SysObjectRetainer.Release(Iter->second.Proxy.Get());
     }
 


### PR DESCRIPTION
ts层调用Delegate的Clear接口内存泄露，SysObjectRetainer.Release参数无效