### PR TITLE
修复静态函数每次调用的时候会查两次对象属性

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -14,16 +14,20 @@ var global = global || (function () { return this; }());
     let loadCPPType = global.puerts.loadCPPType;
     
     let cache = Object.create(null);
-    
+
     let UE = new Proxy(cache, {
-        get: function(classWrapers, name) {
-            if (!(name in classWrapers)) {
-                classWrapers[name] = loadUEType(name);
+        get : function(classWrapers, name)
+        {
+            let value = classWrapers[name];
+            if (!value)
+            {
+                value = loadUEType(name);
+                classWrapers[name] = value;
             }
-            return classWrapers[name];
+            return value;
         }
     });
-    
+
     const TNAMESPACE = 0;
     const TENUM = 1
     const TBLUEPRINT = 2;
@@ -76,10 +80,13 @@ var global = global || (function () { return this; }());
     
     let CPP = new Proxy(cache, {
         get: function(classWrapers, name) {
-            if (!(name in classWrapers)) {
-                classWrapers[name] = loadCPPType(name);
+            let value = classWrapers[name];
+            if (!value)
+            {
+                value = loadCPPType(name);
+                classWrapers[name] = value;
             }
-            return classWrapers[name];
+            return value;
         }
     });
     


### PR DESCRIPTION
发现使用静态方法始终比使用成员方法慢一些，调查以后发现每次访问 `UE.XXX`的时候都会查两次`classwrapper`内的值。

```ts
UE.TestClass.StaticAdd(1,2)
```