### PR TITLE
增加一个宏，允许ts不持有ueobject

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -122,6 +122,9 @@ var global = global || (function () { return this; }());
     
     let rawmakeclass = global.__tgjsMakeUClass
     global.__tgjsMakeUClass = undefined;
+
+    puerts.SetJsTakeRef = global.__tgjsSetJsTakeRef
+    global.__tgjsSetJsTakeRef = undefined
     
     function defaultUeConstructor(){};
     

--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -123,7 +123,7 @@ var global = global || (function () { return this; }());
     let rawmakeclass = global.__tgjsMakeUClass
     global.__tgjsMakeUClass = undefined;
 
-    puerts.SetJsTakeRef = global.__tgjsSetJsTakeRef
+    puerts.setJsTakeRef = global.__tgjsSetJsTakeRef
     global.__tgjsSetJsTakeRef = undefined
     
     function defaultUeConstructor(){};

--- a/unreal/Puerts/Source/JsEnv/JsEnv.Build.cs
+++ b/unreal/Puerts/Source/JsEnv/JsEnv.Build.cs
@@ -87,14 +87,14 @@ public class JsEnv : ModuleRules
             PublicDefinitions.Add("PUERTS_FORCE_CPP_UFUNCTION=0");
         }
 
-        bool bTsKeepReference = true;
-        if(bTsKeepReference)
+        bool bKeepUObjectReference = true;
+        if(bKeepUObjectReference)
         {
-            PublicDefinitions.Add("PUERTS_TS_KEEP_REFERENCE=1");
+            PublicDefinitions.Add("PUERTS_KEEP_UOBJECT_REFERENCE=1");
         }
         else
         {
-            PublicDefinitions.Add("PUERTS_TS_KEEP_REFERENCE=0");
+            PublicDefinitions.Add("PUERTS_KEEP_UOBJECT_REFERENCE=0");
         }
 
         bool UseWasm = false;

--- a/unreal/Puerts/Source/JsEnv/JsEnv.Build.cs
+++ b/unreal/Puerts/Source/JsEnv/JsEnv.Build.cs
@@ -87,6 +87,16 @@ public class JsEnv : ModuleRules
             PublicDefinitions.Add("PUERTS_FORCE_CPP_UFUNCTION=0");
         }
 
+        bool bTsKeepReference = true;
+        if(bTsKeepReference)
+        {
+            PublicDefinitions.Add("PUERTS_TS_KEEP_REFERENCE=1");
+        }
+        else
+        {
+            PublicDefinitions.Add("PUERTS_TS_KEEP_REFERENCE=0");
+        }
+
         bool UseWasm = false;
         if (UseWasm)
         {

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -1065,7 +1065,7 @@ void FJsEnvImpl::NewObjectByClass(const v8::FunctionCallbackInfo<v8::Value>& Inf
                 NeedJsTakeRef = false;
             }
         }
-#if PUERTS_TS_KEEP_REFERENCE
+#if PUERTS_KEEP_UOBJECT_REFERENCE
 #else
         if (NeedJsTakeRef)
         {
@@ -1705,7 +1705,7 @@ bool FJsEnvImpl::IsTypeScriptGeneratedClass(UClass* Class)
 void FJsEnvImpl::Bind(FClassWrapper* ClassWrapper, UObject* UEObject,
     v8::Local<v8::Object> JSObject)    // Just call in FClassReflection::Call, new a Object
 {
-#if PUERTS_TS_KEEP_REFERENCE
+#if PUERTS_KEEP_UOBJECT_REFERENCE
     const bool IsNativeTakeJsRef = ClassWrapper->IsNativeTakeJsRef;
 #else
     const bool ClassWrapperIsNativeTakeJsRef = ClassWrapper->IsNativeTakeJsRef;    //这个值只有mixin会进行设置
@@ -3045,7 +3045,7 @@ FJsEnvImpl::FTemplateInfo* FJsEnvImpl::GetTemplateInfoOfType(UStruct* InStruct, 
                         .ToLocalChecked());
 #endif
             }
-#if PUERTS_TS_KEEP_REFERENCE
+#if PUERTS_KEEP_UOBJECT_REFERENCE
             StructWrapper->IsNativeTakeJsRef = StructWrapper->IsTypeScriptGeneratedClass = IsTypeScriptGeneratedClass(Class);
 #endif
             auto SuperClass = Class->GetSuperClass();

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -498,6 +498,8 @@ FJsEnvImpl::FJsEnvImpl(std::shared_ptr<IJSModuleLoader> InModuleLoader, std::sha
 
     MethodBindingHelper<&FJsEnvImpl::NewObjectByClass>::Bind(Isolate, Context, Global, "__tgjsNewObject", This);
 
+    MethodBindingHelper<&FJsEnvImpl::SetJsTakeRefInTs>::Bind(Isolate, Context, Global, "__tgjsSetJsTakeRef", This);
+
     MethodBindingHelper<&FJsEnvImpl::NewStructByScriptStruct>::Bind(Isolate, Context, Global, "__tgjsNewStruct", This);
 
 #if !defined(ENGINE_INDEPENDENT_JSENV)
@@ -1032,7 +1034,7 @@ void FJsEnvImpl::NewObjectByClass(const v8::FunctionCallbackInfo<v8::Value>& Inf
 
     if (Class)
     {
-        if (Info.Length() > 1)
+        if (Info.Length() > 1 && !Info[1]->IsNullOrUndefined())
         {
             Outer = FV8Utils::GetUObject(Context, Info[1]);
             if (FV8Utils::IsReleasedPtr(Outer))
@@ -1041,17 +1043,37 @@ void FJsEnvImpl::NewObjectByClass(const v8::FunctionCallbackInfo<v8::Value>& Inf
                 return;
             }
         }
-        if (Info.Length() > 2)
+        if (Info.Length() > 2 && !Info[2]->IsNullOrUndefined())
         {
             Name = FName(*FV8Utils::ToFString(Isolate, Info[2]));
         }
-        if (Info.Length() > 3)
+        if (Info.Length() > 3 && !Info[3]->IsNullOrUndefined())
         {
             ObjectFlags = (EObjectFlags) (Info[3]->Int32Value(Context).ToChecked());
         }
         UObject* Object = NewObject<UObject>(Outer, Class, Name, ObjectFlags);
 
         auto Result = FV8Utils::IsolateData<IObjectMapper>(Isolate)->FindOrAdd(Isolate, Context, Object->GetClass(), Object);
+        bool NeedJsTakeRef = true;
+        if (Info.Length() > 4 && !Info[4]->IsNullOrUndefined())
+        {
+            if (Info[4]->BooleanValue(Isolate))
+            {
+
+            }
+            else
+            {
+                NeedJsTakeRef = false;
+            }
+        }
+    #if PUERTS_TS_KEEP_REFERENCE
+    #else
+        if (NeedJsTakeRef) {
+            bool Existed;
+            auto TemplateInfoPtr = GetTemplateInfoOfType(Class, Existed);
+            SetJsTakeRef(Object,static_cast<FClassWrapper*>(TemplateInfoPtr->StructWrapper.get()));
+        }
+    #endif
         Info.GetReturnValue().Set(Result);
     }
     else
@@ -1683,20 +1705,29 @@ bool FJsEnvImpl::IsTypeScriptGeneratedClass(UClass* Class)
 void FJsEnvImpl::Bind(FClassWrapper* ClassWrapper, UObject* UEObject,
     v8::Local<v8::Object> JSObject)    // Just call in FClassReflection::Call, new a Object
 {
-    if (!ClassWrapper->IsNativeTakeJsRef)
-    {
-        UserObjectRetainer.Retain(UEObject);
-    }
+#if PUERTS_TS_KEEP_REFERENCE
+    const bool IsNativeTakeJsRef = ClassWrapper->IsNativeTakeJsRef;
+#else
+    const bool ClassWrapperIsNativeTakeJsRef = ClassWrapper->IsNativeTakeJsRef; //这个值只有mixin会进行设置
+    const bool IsAsset = UEObject->HasAnyFlags(RF_DefaultSubObject | RF_ClassDefaultObject | RF_ArchetypeObject) || UEObject->IsAsset();
+    const bool IsUClass = UEObject->IsA<UClass>();
+    const bool IsNativeTakeJsRef = (IsAsset || IsUClass) ? false : ClassWrapperIsNativeTakeJsRef;
+#endif
 
     DataTransfer::SetPointer(MainIsolate, JSObject, UEObject, 0);
     DataTransfer::SetPointer(MainIsolate, JSObject, nullptr, 1);
     ObjectMap.Emplace(UEObject, v8::UniquePersistent<v8::Value>(MainIsolate, JSObject));
 
-    if (!ClassWrapper->IsNativeTakeJsRef)
+    if (!IsNativeTakeJsRef)
     {
-        ObjectMap[UEObject].SetWeak<UClass>(
-            (UClass*) ClassWrapper->Struct.Get(), FClassWrapper::OnGarbageCollected, v8::WeakCallbackType::kInternalFields);
+        SetJsTakeRef(UEObject, ClassWrapper);
     }
+}
+
+void FJsEnvImpl::SetJsTakeRef(UObject* UEObject, FClassWrapper* ClassWrapper)
+{
+    UserObjectRetainer.Retain(UEObject);
+    ObjectMap[UEObject].SetWeak<UClass>(Cast<UClass>(ClassWrapper->Struct.Get()), FClassWrapper::OnGarbageCollected, v8::WeakCallbackType::kInternalFields);
 }
 
 void FJsEnvImpl::UnBind(UClass* Class, UObject* UEObject, bool ResetPointer)
@@ -3012,9 +3043,9 @@ FJsEnvImpl::FTemplateInfo* FJsEnvImpl::GetTemplateInfoOfType(UStruct* InStruct, 
                         .ToLocalChecked());
 #endif
             }
-
+#if PUERTS_TS_KEEP_REFERENCE
             StructWrapper->IsNativeTakeJsRef = StructWrapper->IsTypeScriptGeneratedClass = IsTypeScriptGeneratedClass(Class);
-
+#endif
             auto SuperClass = Class->GetSuperClass();
             if (SuperClass)
             {
@@ -3284,6 +3315,19 @@ void FJsEnvImpl::UEClassToJSClass(const v8::FunctionCallbackInfo<v8::Value>& Inf
     {
         FV8Utils::ThrowException(Isolate, FString::Printf(TEXT("argument #0 expect a UField")));
     }
+}
+
+void FJsEnvImpl::SetJsTakeRefInTs(const v8::FunctionCallbackInfo<v8::Value>& Info)
+{
+    v8::Isolate* Isolate = Info.GetIsolate();
+    v8::Local<v8::Context> Context = Isolate->GetCurrentContext();
+    CHECK_V8_ARGS(EArgObject);
+
+    UObject* Object = FV8Utils::GetUObject(Context, Info[0]);
+
+    bool Existed;
+    auto TemplateInfoPtr = GetTemplateInfoOfType(Object->GetClass(), Existed);
+    SetJsTakeRef(Object, static_cast<FClassWrapper*>(TemplateInfoPtr->StructWrapper.get()));
 }
 
 bool FJsEnvImpl::GetContainerTypeProperty(v8::Local<v8::Context> Context, v8::Local<v8::Value> Value, PropertyMacro** PropertyPtr)

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -1059,21 +1059,21 @@ void FJsEnvImpl::NewObjectByClass(const v8::FunctionCallbackInfo<v8::Value>& Inf
         {
             if (Info[4]->BooleanValue(Isolate))
             {
-
             }
             else
             {
                 NeedJsTakeRef = false;
             }
         }
-    #if PUERTS_TS_KEEP_REFERENCE
-    #else
-        if (NeedJsTakeRef) {
+#if PUERTS_TS_KEEP_REFERENCE
+#else
+        if (NeedJsTakeRef)
+        {
             bool Existed;
             auto TemplateInfoPtr = GetTemplateInfoOfType(Class, Existed);
-            SetJsTakeRef(Object,static_cast<FClassWrapper*>(TemplateInfoPtr->StructWrapper.get()));
+            SetJsTakeRef(Object, static_cast<FClassWrapper*>(TemplateInfoPtr->StructWrapper.get()));
         }
-    #endif
+#endif
         Info.GetReturnValue().Set(Result);
     }
     else
@@ -1708,8 +1708,9 @@ void FJsEnvImpl::Bind(FClassWrapper* ClassWrapper, UObject* UEObject,
 #if PUERTS_TS_KEEP_REFERENCE
     const bool IsNativeTakeJsRef = ClassWrapper->IsNativeTakeJsRef;
 #else
-    const bool ClassWrapperIsNativeTakeJsRef = ClassWrapper->IsNativeTakeJsRef; //这个值只有mixin会进行设置
-    const bool IsAsset = UEObject->HasAnyFlags(RF_DefaultSubObject | RF_ClassDefaultObject | RF_ArchetypeObject) || UEObject->IsAsset();
+    const bool ClassWrapperIsNativeTakeJsRef = ClassWrapper->IsNativeTakeJsRef;    //这个值只有mixin会进行设置
+    const bool IsAsset =
+        UEObject->HasAnyFlags(RF_DefaultSubObject | RF_ClassDefaultObject | RF_ArchetypeObject) || UEObject->IsAsset();
     const bool IsUClass = UEObject->IsA<UClass>();
     const bool IsNativeTakeJsRef = (IsAsset || IsUClass) ? false : ClassWrapperIsNativeTakeJsRef;
 #endif
@@ -1727,7 +1728,8 @@ void FJsEnvImpl::Bind(FClassWrapper* ClassWrapper, UObject* UEObject,
 void FJsEnvImpl::SetJsTakeRef(UObject* UEObject, FClassWrapper* ClassWrapper)
 {
     UserObjectRetainer.Retain(UEObject);
-    ObjectMap[UEObject].SetWeak<UClass>(Cast<UClass>(ClassWrapper->Struct.Get()), FClassWrapper::OnGarbageCollected, v8::WeakCallbackType::kInternalFields);
+    ObjectMap[UEObject].SetWeak<UClass>(
+        Cast<UClass>(ClassWrapper->Struct.Get()), FClassWrapper::OnGarbageCollected, v8::WeakCallbackType::kInternalFields);
 }
 
 void FJsEnvImpl::UnBind(UClass* Class, UObject* UEObject, bool ResetPointer)

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -134,7 +134,7 @@ public:
 
 public:
     bool IsTypeScriptGeneratedClass(UClass* Class);
-    
+
     void SetJsTakeRef(UObject* UEObject, FClassWrapper* ClassWrapper);
 
     virtual void Bind(FClassWrapper* ClassWrapper, UObject* UEObject, v8::Local<v8::Object> JSObject) override;

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -134,6 +134,8 @@ public:
 
 public:
     bool IsTypeScriptGeneratedClass(UClass* Class);
+    
+    void SetJsTakeRef(UObject* UEObject, FClassWrapper* ClassWrapper);
 
     virtual void Bind(FClassWrapper* ClassWrapper, UObject* UEObject, v8::Local<v8::Object> JSObject) override;
 
@@ -280,6 +282,8 @@ private:
     void LoadCppType(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     void UEClassToJSClass(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+    void SetJsTakeRefInTs(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
     bool GetContainerTypeProperty(v8::Local<v8::Context> Context, v8::Local<v8::Value> Value, PropertyMacro** PropertyPtr);
 

--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
@@ -87,7 +87,11 @@ protected:
 
     TWeakObjectPtr<UStruct> Struct;
 
+    #if PUERTS_TS_KEEP_REFERENCE
     bool IsNativeTakeJsRef = false;
+#else
+    bool IsNativeTakeJsRef = true;
+#endif
 
     bool IsTypeScriptGeneratedClass = false;
 

--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
@@ -87,7 +87,7 @@ protected:
 
     TWeakObjectPtr<UStruct> Struct;
 
-#if PUERTS_TS_KEEP_REFERENCE
+#if PUERTS_KEEP_UOBJECT_REFERENCE
     bool IsNativeTakeJsRef = false;
 #else
     bool IsNativeTakeJsRef = true;

--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.h
@@ -87,7 +87,7 @@ protected:
 
     TWeakObjectPtr<UStruct> Struct;
 
-    #if PUERTS_TS_KEEP_REFERENCE
+#if PUERTS_TS_KEEP_REFERENCE
     bool IsNativeTakeJsRef = false;
 #else
     bool IsNativeTakeJsRef = true;

--- a/unreal/Puerts/Typing/puerts/index.d.ts
+++ b/unreal/Puerts/Typing/puerts/index.d.ts
@@ -89,4 +89,6 @@ declare module "puerts" {
     } & T
 
     function $async<T>(x: T) : AsyncObject<T>;*/
+
+    function SetJsTakeRef(object : Object) : void;
 }

--- a/unreal/Puerts/Typing/puerts/index.d.ts
+++ b/unreal/Puerts/Typing/puerts/index.d.ts
@@ -90,5 +90,5 @@ declare module "puerts" {
 
     function $async<T>(x: T) : AsyncObject<T>;*/
 
-    function SetJsTakeRef(object : Object) : void;
+    function setJsTakeRef(object : Object) : void;
 }

--- a/unreal/Puerts/Typing/ue/puerts.d.ts
+++ b/unreal/Puerts/Typing/ue/puerts.d.ts
@@ -122,7 +122,7 @@ declare module "ue" {
         [P in DataPropertyNames<T>]: T[P] extends object ? DataPropertiesOnly<T[P]> : T[P]
     };
 
-    function NewObject(Cls: Class, Outer?: Object, Name?:string, ObjectFlags?: number): Object;
+    function NewObject(Cls: Class, Outer?: Object, Name?:string, ObjectFlags?: number, JsTakeRef?: boolean): Object;
     
     function NewStruct(St: ScriptStruct): object;
 


### PR DESCRIPTION
主要解决uobject的outer导致的泄露问题。以animbp为例，animbp的outer是actor，假设ts不小心通过actor的tsobject持有了animbp，那么即便actor被ue标记为pendingkill，也会因为animbp还没有pendingkill，导致无法回收。
打开宏后，默认情况下，ts不会持有uobject的引用，以下三种情况除外
1. 在ts里面通过newobject创建的object，会被ts持有引用
2. cdo，uclass以及asset，会被ts持有引用
3. 在mixin中指定了ts持有引用的uobject
有的时候，newobject创建的object也不希望由ts持有引用，因此newobject增加了最后一个参数，填false即可
有时候上面三种以外的情况也会需要由ts来持有引用，比如创建材质之后，在callback里面调用，因此提供了puerts.SetJsTakeRef,但该函数的使用要慎重，需要自己确保ts能正常释放，否则还是会造成泄露