### PR TITLE
Fixes boxing issue in unity StaticWrapper generation

### DIFF
--- a/unity/Assets/core/upm/Editor/Resources/puerts/templates/wrapper.tpl.mjs
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/templates/wrapper.tpl.mjs
@@ -51,7 +51,7 @@ class ArgumentCodeGenerator {
         } else if (typeName in fixGet) {
             return `${typeName} arg${this.index} = ${fixGet[typeName](this.v8Value(), isByRef)}`;
         } else {
-            return `argobj${this.index} = argobj${this.index} != null ? argobj${this.index} : StaticTranslate<${typeInfo.TypeName}>.Get((int)data, isolate, NativeValueApi.GetValueFromArgument, v8Value${this.index}, ${typeInfo.IsByRef ? "true" : "false"}); ${typeName} arg${this.index} = (${typeName})argobj${this.index}`
+            return `${typeName} arg${this.index} = StaticTranslate<${typeInfo.TypeName}>.Get((int)data, isolate, NativeValueApi.GetValueFromArgument, v8Value${this.index}, ${typeInfo.IsByRef ? "true" : "false"})`
         }
     }
 


### PR DESCRIPTION
I actually made this change awhile back when debugging an issue with StaticWrapper still generating garbage in Unity. My memory is a bit fuzzy about it now, but this should fix #1527 

I basically removed some redundancies in the old `getArg()` line. But as I'm still new to Puerts, please advise if I'm missing anything here.