### PR TITLE
创建GenericDelegate时记录js堆栈，在CheckLiveness失败时附带堆栈方便定位

### DIFF
--- a/unity/Assets/core/upm/Runtime/Src/Default/JSType/GenericDelegate.cs
+++ b/unity/Assets/core/upm/Runtime/Src/Default/JSType/GenericDelegate.cs
@@ -84,7 +84,7 @@ namespace Puerts
         {
             if (obj != null)
             {
-                var gd = new GenericDelegate(IntPtr.Zero, null);
+                var gd = new GenericDelegate(IntPtr.Zero, null, null);
                 gd.Action();
                 gd.Action(obj);
                 gd.Action(obj, obj);
@@ -113,7 +113,13 @@ namespace Puerts
             {
                 return maybeOne.Target as GenericDelegate;
             }
-            GenericDelegate genericDelegate = new GenericDelegate(ptr, jsEnv);
+
+            string stacktrace = null;
+#if UNITY_EDITOR
+            //stacktrace = jsEnv.Eval<string>("new Error().stack");
+            stacktrace = PuertsDLL.GetJSStackTrace(jsEnv.isolate);
+#endif
+            GenericDelegate genericDelegate = new GenericDelegate(ptr, jsEnv, stacktrace);
             nativePtrToGenericDelegate[ptr] = new WeakReference(genericDelegate);
             return genericDelegate;
         }
@@ -331,17 +337,21 @@ namespace Puerts
         private Delegate firstValue = null;
         private Dictionary<Type, Delegate> bindTo = null;
 
+        private string stacktrace;
+
         internal IntPtr getJsFuncPtr() 
         {
             return nativeJsFuncPtr;
         }
 
-        internal GenericDelegate(IntPtr nativeJsFuncPtr, JsEnv jsEnv)
+        internal GenericDelegate(IntPtr nativeJsFuncPtr, JsEnv jsEnv, string stacktrace)
         {
             this.nativeJsFuncPtr = nativeJsFuncPtr;
             jsEnv.IncFuncRef(nativeJsFuncPtr);
             isolate = jsEnv != null ? jsEnv.isolate : IntPtr.Zero;
             this.jsEnv = jsEnv;
+            this.stacktrace = stacktrace;
+
         }
 
         internal void Close()
@@ -355,8 +365,8 @@ namespace Puerts
         {
             if (nativeJsFuncPtr == IntPtr.Zero)
             {
-                if (shouldThrow) throw new Exception("JsEnv has been disposed");
-            } 
+                if (shouldThrow) throw new Exception("JsEnv has been disposed, stacktrace:" + (string.IsNullOrEmpty(this.stacktrace) ? "unknown" : this.stacktrace));
+            }
             else 
             {
                 jsEnv.CheckLiveness();

--- a/unity/Assets/core/upm/Runtime/Src/Default/JSType/GenericDelegate.cs
+++ b/unity/Assets/core/upm/Runtime/Src/Default/JSType/GenericDelegate.cs
@@ -337,7 +337,9 @@ namespace Puerts
         private Delegate firstValue = null;
         private Dictionary<Type, Delegate> bindTo = null;
 
+#if UNITY_EDITOR
         private string stacktrace;
+#endif
 
         internal IntPtr getJsFuncPtr() 
         {
@@ -350,8 +352,9 @@ namespace Puerts
             jsEnv.IncFuncRef(nativeJsFuncPtr);
             isolate = jsEnv != null ? jsEnv.isolate : IntPtr.Zero;
             this.jsEnv = jsEnv;
+#if UNITY_EDITOR
             this.stacktrace = stacktrace;
-
+#endif
         }
 
         internal void Close()
@@ -365,7 +368,11 @@ namespace Puerts
         {
             if (nativeJsFuncPtr == IntPtr.Zero)
             {
+#if UNITY_EDITOR
                 if (shouldThrow) throw new Exception("JsEnv has been disposed, stacktrace:" + (string.IsNullOrEmpty(this.stacktrace) ? "unknown" : this.stacktrace));
+#else
+                if (shouldThrow) throw new Exception("JsEnv has been disposed");
+#endif
             }
             else 
             {

--- a/unity/Assets/core/upm/Runtime/Src/Default/JsEnv.cs
+++ b/unity/Assets/core/upm/Runtime/Src/Default/JsEnv.cs
@@ -199,7 +199,7 @@ namespace Puerts
                 string exceptionInfo = PuertsDLL.GetLastExceptionInfo(isolate);
                 throw new Exception(exceptionInfo);
             }
-            JSObjectValueGetter = new GenericDelegate(ptr, this);
+            JSObjectValueGetter = new GenericDelegate(ptr, this, "JSObjectValueGetter");
 #if THREAD_SAFE
             }
 #endif
@@ -301,7 +301,7 @@ namespace Puerts
                     string exceptionInfo = PuertsDLL.GetLastExceptionInfo(isolate);
                     throw new Exception(exceptionInfo);
                 }
-                ModuleExecutor = new GenericDelegate(ptr, this);
+                ModuleExecutor = new GenericDelegate(ptr, this, "ModuleExecutor");
             }
             JSObject jso = ModuleExecutor.Func<string, JSObject>(specifier);
 
@@ -319,7 +319,7 @@ namespace Puerts
                     string exceptionInfo = PuertsDLL.GetLastExceptionInfo(isolate);
                     throw new Exception(exceptionInfo);
                 }
-                ModuleExecutor = new GenericDelegate(ptr, this);
+                ModuleExecutor = new GenericDelegate(ptr, this, "ModuleExecutor");
             }
             return ModuleExecutor.Func<string, JSObject>(specifier);
         }

--- a/unity/Assets/core/upm/Runtime/Src/Default/JsEnv.cs
+++ b/unity/Assets/core/upm/Runtime/Src/Default/JsEnv.cs
@@ -102,7 +102,7 @@ namespace Puerts
 
         public JsEnv(ILoader loader, int debugPort, BackendType backend, IntPtr externalRuntime, IntPtr externalContext)
         {
-            const int libVersionExpect = 33;
+            const int libVersionExpect = 34;
             int libVersion = PuertsDLL.GetApiLevel();
             if (libVersion != libVersionExpect)
             {

--- a/unity/Assets/core/upm/Runtime/Src/Default/Native/PuertsDLL.cs
+++ b/unity/Assets/core/upm/Runtime/Src/Default/Native/PuertsDLL.cs
@@ -619,6 +619,15 @@ namespace Puerts
         public static extern IntPtr GetArrayBufferFromValue(IntPtr isolate, IntPtr value, out int length, bool isOut);
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetArrayBufferFromResult(IntPtr function, out int length);
+
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr GetJSStackTrace(IntPtr isolate, out int len);
+        public static string GetJSStackTrace(IntPtr isolate)
+        {
+            int strlen;
+            IntPtr str = GetJSStackTrace(isolate, out strlen);
+            return GetStringFromNative(str, strlen);
+        }
     }
 }
 

--- a/unity/native_src/Inc/BackendEnv.h
+++ b/unity/native_src/Inc/BackendEnv.h
@@ -127,6 +127,8 @@ namespace PUERTS_NAMESPACE
         bool InspectorTick();
 
         bool ClearModuleCache(v8::Isolate* Isolate, v8::Local<v8::Context> Context, const char* Path);
+
+        std::string GetJSStackTrace();
     };
 
 #if WITH_NODEJS

--- a/unity/native_src/Inc/IPuertsPlugin.h
+++ b/unity/native_src/Inc/IPuertsPlugin.h
@@ -179,6 +179,8 @@ public:
 
     virtual const char* GetFunctionLastExceptionInfo(void* Function, int *Length) = 0;
 
+    virtual const char* GetJSStackTrace(int *Length) = 0;
+
     //-------------------------- end cs call js --------------------------
 
     //-------------------------- begin debug --------------------------

--- a/unity/native_src/Inc/JSEngine.h
+++ b/unity/native_src/Inc/JSEngine.h
@@ -190,5 +190,7 @@ public:
     JSFunction* GetModuleExecutor();
 
     v8::Local<v8::FunctionTemplate> ToTemplate(v8::Isolate* Isolate, bool IsStatic, CSharpFunctionCallback Callback, int64_t Data);
+
+    std::string GetJSStackTrace();
 };
 }

--- a/unity/native_src/Src/JSEngine.cpp
+++ b/unity/native_src/Src/JSEngine.cpp
@@ -731,4 +731,9 @@ namespace PUERTS_NAMESPACE
 
         return BackendEnv.ClearModuleCache(MainIsolate, Context, Path);
     }
+
+    std::string JSEngine::GetJSStackTrace()
+	{
+        return BackendEnv.GetJSStackTrace();
+	}
 }

--- a/unity/native_src/Src/PluginImpl.cpp
+++ b/unity/native_src/Src/PluginImpl.cpp
@@ -58,6 +58,8 @@ public:
     
     virtual void* GetResultInfo() override;
 
+    virtual const char* GetJSStackTrace(int* Length) override;
+
     //-------------------------- begin js call cs --------------------------
     virtual void* GetArgumentValue(const void* Info, int Index) override;
 
@@ -300,6 +302,16 @@ void* V8Plugin::GetModuleExecutor()
 void* V8Plugin::GetResultInfo()
 {
     return &(jsEngine.ResultInfo);
+}
+
+const char* V8Plugin::GetJSStackTrace(int* Length)
+{
+    std::string str = jsEngine.GetJSStackTrace();
+    *Length = static_cast<int>(str.length());
+    if (jsEngine.StrBuffer.size() < *Length + 1)
+        jsEngine.StrBuffer.reserve(*Length + 1);
+    memcpy(jsEngine.StrBuffer.data(), str.c_str(), *Length);
+    return jsEngine.StrBuffer.data();
 }
 
 //-------------------------- begin js call cs --------------------------

--- a/unity/native_src/Src/Puerts.cpp
+++ b/unity/native_src/Src/Puerts.cpp
@@ -9,7 +9,7 @@
 #include "V8Utils.h"
 #include "Log.h"
 
-#define API_LEVEL 33
+#define API_LEVEL 34
 
 using puerts::JSEngine;
 using puerts::FValue;
@@ -983,6 +983,17 @@ V8_EXPORT void SetLogCallback(LogCallback Log, LogCallback LogWarning, LogCallba
     GLogCallback = Log;
     GLogWarningCallback = LogError;
     GLogErrorCallback = LogWarning;
+}
+
+V8_EXPORT const char* GetJSStackTrace(v8::Isolate* Isolate, int* Length)
+{
+    auto JsEngine = FV8Utils::IsolateData<JSEngine>(Isolate);
+    std::string str = JsEngine->GetJSStackTrace();
+    *Length = static_cast<int>(str.length());
+    if (JsEngine->StrBuffer.size() < *Length + 1)
+        JsEngine->StrBuffer.reserve(*Length + 1);
+    memcpy(JsEngine->StrBuffer.data(), str.c_str(), *Length);
+    return JsEngine->StrBuffer.data();
 }
 
 //-------------------------- end debug --------------------------

--- a/unity/native_src/Src/PuertsMultBackend.cpp
+++ b/unity/native_src/Src/PuertsMultBackend.cpp
@@ -521,6 +521,11 @@ PUERTS_EXPORT void SetLogCallback(LogCallback Log, LogCallback LogWarning, LogCa
     GLogErrorCallback = LogWarning;
 }
 
+PUERTS_EXPORT const char* GetJSStackTrace(puerts::IPuertsPlugin* plugin, int* Length)
+{
+    return plugin->GetJSStackTrace(Length);
+}
+
 //-------------------------- end debug --------------------------
 
 #ifdef __cplusplus

--- a/unity/native_src/Src/PuertsMultBackend.cpp
+++ b/unity/native_src/Src/PuertsMultBackend.cpp
@@ -83,9 +83,8 @@ PUERTS_EXPORT puerts::IPuertsPlugin* CreateJSEngineWithExternalEnv(int backend, 
     {
         return puerts::CreateQJSPlugin(external_quickjs_runtime, external_quickjs_context);
     }
-#else
-    return nullptr;
 #endif
+    return nullptr;
 }
 
 PUERTS_EXPORT void DestroyJSEngine(puerts::IPuertsPlugin* plugin)

--- a/unity/native_src/Src/PuertsMultBackend.cpp
+++ b/unity/native_src/Src/PuertsMultBackend.cpp
@@ -33,7 +33,7 @@
 #endif
 #endif  // _WIN32
 
-#define API_LEVEL 33
+#define API_LEVEL 34
 
 LogCallback GLogCallback = nullptr;
 LogCallback GLogWarningCallback = nullptr;


### PR DESCRIPTION
feat: 增加GetJSStackTrace api
feat: 创建GenericDelegate时记录js堆栈，在CheckLiveness失败时附带堆栈方便定位
fix: 消除CreateJSEngineWithExternalEnv中的warnning