### PR TITLE
[Unreal] Bug:解决错误的将父类的hideCategories赋值给蓝图以及错误的覆盖了ts收集到的hideCategories元数据

### DIFF
--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintMetaData.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintMetaData.cpp
@@ -116,18 +116,22 @@ void UPEClassMetaData::MergeClassCategories(UClass* InParentClass)
     {
         return;
     }
-
-    TArray<FString> ParentHideCategories = GetClassMetaDataValues(InParentClass, NAME_HideCategories);
+    
     TArray<FString> ParentShowCategories = GetClassMetaDataValues(InParentClass, NAME_ShowCategories);
     TArray<FString> ParentHideFunctions = GetClassMetaDataValues(InParentClass, NAME_HideFunctions);
     TArray<FString> ParentAutoExpandCategories = GetClassMetaDataValues(InParentClass, NAME_AutoExpandCategories);
     TArray<FString> ParentAutoCollapseCategories = GetClassMetaDataValues(InParentClass, NAME_AutoCollapseCategories);
 
     //	add parent categories
-    HideCategories.Append(MoveTemp(ParentHideCategories));
     ShowSubCategories.Append(MoveTemp(ParentShowCategories));
     HideFunctions.Append(MoveTemp(ParentHideFunctions));
-
+    //If metadata is collected from ts
+    FString* ExistingValue = MetaData.Find(NAME_HideCategories);
+    if (ExistingValue)
+    {
+        ExistingValue->ParseIntoArray(HideCategories, TEXT(" "), true);
+    }
+    
     //	for show categories
     for (const FString& Value : ShowCategories)
     {
@@ -203,10 +207,6 @@ void UPEClassMetaData::MergeClassCategories(UClass* InParentClass)
     if (AutoExpandCategories.Num() > 0)
     {
         MetaData.Add(NAME_AutoExpandCategories, FString::Join(AutoExpandCategories, TEXT(" ")));
-    }
-    if (HideCategories.Num() > 0)
-    {
-        MetaData.Add(NAME_HideCategories, FString::Join(HideCategories, TEXT(" ")));
     }
     if (ShowSubCategories.Num() > 0)
     {
@@ -330,10 +330,7 @@ void UPEClassMetaData::SyncClassToBlueprint(UClass* InClass, UBlueprint* InBluep
         InClass->HasMetaData(TEXT("DisplayName")) ? InClass->GetMetaData(TEXT("DisplayName")) : FString{};
     InBlueprint->BlueprintType = (InClass->ClassFlags & CLASS_Const) ? BPTYPE_Const : BPTYPE_Normal;
     InBlueprint->BlueprintCategory = InClass->HasMetaData(TEXT("Category")) ? InClass->GetMetaData(TEXT("Category")) : FString{};
-    if (InClass->HasMetaData(TEXT("HideCategories")))
-    {
-        InClass->GetMetaData(TEXT("HideCategories")).ParseIntoArray(InBlueprint->HideCategories, TEXT(" "), true);
-    }
+    InBlueprint->HideCategories = HideCategories;
 }
 
 void UPEClassMetaData::SetAndValidateWithinClass(UClass* InClass)

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintMetaData.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintMetaData.cpp
@@ -116,7 +116,7 @@ void UPEClassMetaData::MergeClassCategories(UClass* InParentClass)
     {
         return;
     }
-    
+
     TArray<FString> ParentShowCategories = GetClassMetaDataValues(InParentClass, NAME_ShowCategories);
     TArray<FString> ParentHideFunctions = GetClassMetaDataValues(InParentClass, NAME_HideFunctions);
     TArray<FString> ParentAutoExpandCategories = GetClassMetaDataValues(InParentClass, NAME_AutoExpandCategories);
@@ -125,13 +125,13 @@ void UPEClassMetaData::MergeClassCategories(UClass* InParentClass)
     //	add parent categories
     ShowSubCategories.Append(MoveTemp(ParentShowCategories));
     HideFunctions.Append(MoveTemp(ParentHideFunctions));
-    //If metadata is collected from ts
+    // If metadata is collected from ts
     FString* ExistingValue = MetaData.Find(NAME_HideCategories);
     if (ExistingValue)
     {
         ExistingValue->ParseIntoArray(HideCategories, TEXT(" "), true);
     }
-    
+
     //	for show categories
     for (const FString& Value : ShowCategories)
     {

--- a/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintMetaData.h
+++ b/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintMetaData.h
@@ -461,7 +461,7 @@ private:
      * @param InClass
      * @param InBlueprint
      */
-    static void SyncClassToBlueprint(UClass* InClass, UBlueprint* InBlueprint);
+    void SyncClassToBlueprint(UClass* InClass, UBlueprint* InBlueprint);
 
 private:
     /**


### PR DESCRIPTION
在原有代码中存在两个问题
1.错误的从蓝图生成类里获取hideCategories这个hideCategories包含了父类的和蓝图本身的实际上蓝图的hideCategories属性不应该有父类的，这会导致每次编译（ts编译也就是修改了ts文件触发的编译不是在蓝图哪里编译）都会增加父类的hideCategories到蓝图中（在父类定义hideCategories即可复现，可以查看蓝图中的class setting中的hideCategories验证）
2.从ts文件收集到的元数据会被覆盖掉（即add函数，其他使用了add函数可能也有次问题）会导致ts定义了uclass.hideCategories="testts1 testts2"并不生效（即在蓝图的class setting中不会查看到）
所以进行了修改，主要思路是只将ts中收集到的数据赋值给蓝图的hideCategories，当然这里也存在一个问题就是蓝图中定义的hideCategories会被覆盖到，但是考虑到没法做到同时兼顾ts的hideCategories和蓝图的hideCategories所以只保留了ts的（原因在于同时保留蓝图的话，蓝图中记录的hideCategories分不清是ts的还是蓝图定义的，这就会导致无法正确删除掉hideCategories）