### PR TITLE
[unreal]Fix:增加对Class Metadata的修改检查来修复删除元数据不会被检测为更改而不重新编译的问题

### DIFF
--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintMetaData.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintMetaData.cpp
@@ -106,8 +106,8 @@ bool UPEClassMetaData::Apply(UClass* InClass, UBlueprint* InBlueprint)
     MergeClassCategories(InClass);
     const bool bFlagsChanged = MergeAndValidateClassFlags(InClass);
     const bool bMetaDataChanged = SetClassMetaData(InClass);
-    SyncClassToBlueprint(InClass, InBlueprint);
-    return bFlagsChanged || bMetaDataChanged;
+    const bool bBlueprintMetaDataChange = SyncClassToBlueprint(InClass, InBlueprint);
+    return bFlagsChanged || bMetaDataChanged || bBlueprintMetaDataChange;
 }
 
 void UPEClassMetaData::MergeClassCategories(UClass* InParentClass)
@@ -313,21 +313,56 @@ TArray<FString> UPEClassMetaData::GetClassMetaDataValues(
     return Result;
 }
 
-void UPEClassMetaData::SyncClassToBlueprint(UClass* InClass, UBlueprint* InBlueprint)
+bool UPEClassMetaData::SyncClassToBlueprint(UClass* InClass, UBlueprint* InBlueprint)
 {
     if (!IsValid(InClass) || !IsValid(InBlueprint))
     {
-        return;
+        return false;
     }
 
-    InBlueprint->bDeprecate = (bool) (InClass->ClassFlags & CLASS_Deprecated);
-    InBlueprint->bGenerateAbstractClass = (bool) (InClass->ClassFlags & CLASS_Abstract);
-    InBlueprint->BlueprintDescription = InClass->HasMetaData(TEXT("Tooltip")) ? InClass->GetMetaData(TEXT("Tooltip")) : FString{};
-    InBlueprint->BlueprintDisplayName =
-        InClass->HasMetaData(TEXT("DisplayName")) ? InClass->GetMetaData(TEXT("DisplayName")) : FString{};
-    InBlueprint->BlueprintType = (InClass->ClassFlags & CLASS_Const) ? BPTYPE_Const : BPTYPE_Normal;
-    InBlueprint->BlueprintCategory = InClass->HasMetaData(TEXT("Category")) ? InClass->GetMetaData(TEXT("Category")) : FString{};
-    InBlueprint->HideCategories = HideCategories;
+    bool onChange = false;
+
+    if (InBlueprint->bDeprecate != (bool) (InClass->ClassFlags & CLASS_Deprecated))
+    {
+        InBlueprint->bDeprecate = (bool) (InClass->ClassFlags & CLASS_Deprecated);
+        onChange = true;
+    }
+    if (InBlueprint->bGenerateAbstractClass != (bool) (InClass->ClassFlags & CLASS_Abstract))
+    {
+        InBlueprint->bGenerateAbstractClass = (bool) (InClass->ClassFlags & CLASS_Abstract);
+        onChange = true;
+    }
+    FString newDescription = InClass->HasMetaData(TEXT("Tooltip")) ? InClass->GetMetaData(TEXT("Tooltip")) : FString{};
+    if (InBlueprint->BlueprintDescription != newDescription)
+    {
+        InBlueprint->BlueprintDescription = newDescription;
+        onChange = true;
+    }
+    FString newDisplayName = InClass->HasMetaData(TEXT("DisplayName")) ? InClass->GetMetaData(TEXT("DisplayName")) : FString{};
+    if (InBlueprint->BlueprintDisplayName != newDisplayName)
+    {
+        InBlueprint->BlueprintDisplayName = newDisplayName;
+        onChange = true;
+    }
+    EBlueprintType newType = (InClass->ClassFlags & CLASS_Const) ? BPTYPE_Const : BPTYPE_Normal;
+    if (InBlueprint->BlueprintType != newType)
+    {
+        InBlueprint->BlueprintType = newType;
+        onChange = true;
+    }
+    FString newCategory = InClass->HasMetaData(TEXT("Category")) ? InClass->GetMetaData(TEXT("Category")) : FString{};
+    if (InBlueprint->BlueprintCategory != newCategory)
+    {
+        InBlueprint->BlueprintCategory = newCategory;
+        onChange = true;
+    }
+    if (InBlueprint->HideCategories != HideCategories)
+    {
+        InBlueprint->HideCategories = HideCategories;
+        onChange = true;
+    }
+
+    return onChange;
 }
 
 void UPEClassMetaData::SetAndValidateWithinClass(UClass* InClass)

--- a/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintMetaData.h
+++ b/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintMetaData.h
@@ -461,7 +461,7 @@ private:
      * @param InClass
      * @param InBlueprint
      */
-    void SyncClassToBlueprint(UClass* InClass, UBlueprint* InBlueprint);
+    bool SyncClassToBlueprint(UClass* InClass, UBlueprint* InBlueprint);
 
 private:
     /**


### PR DESCRIPTION
问题:将@uclass.umeta(uclass.DisplayName="展示名字")中的uclass.DisplayName="展示名字"整个删除，不会触发重新编译蓝图（修改内容和增加没问题）
原因：bool FPEMetaDataUtils::AddMetaData(UField* InField, TMap<FName, FString>& InMetaData) 只对收集到的metadata只做了增加和修改的检查没有处理删除的检查，导致删除metadata不会被识别为发生更改，进而导致没有重新编译
解决方法：按直觉来说应该是在这个函数增加一个检查删除的逻辑，但是该函数使用的蓝图生成类中拥有的元数据可能包含了父类和其他一些定义的元数据，如HideCategories、BlueprintType，如果还是同样的思路来比较蓝图生成类拥有的元数据和收集到的元数据，就需要移除掉这些外来的元数据（即不是在ts文件中定义的元数据），但是这样的话和引擎的耦合比较大，即需要完全查明所有不在ts文件中定义的但是在蓝图生成类中有的（还可能因为版本不同而不同），故采取了另一种方法：
考虑到编译蓝图完全依赖于蓝图类，我们可以只检查puerts本身实现的能够正确配置的元数据是否被删除了即可，即SyncClassToBlueprint这个函数中同步的那些元数据（其他不在该函数赋值的元数据，本身即使编译了也不会正确赋值到蓝图中诸如一些弃用的或者是在编译过程中会被覆盖的元数据）
