### PR TITLE
[unreal]将蓝图中显示的变量顺序与TS文件中定义的变量顺序保持一致

### DIFF
--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -1172,7 +1172,7 @@ void UPEBlueprintAsset::AddMemberVariableWithMetaData(FName InNewVarName, FPEGra
     const int32 VarIndex = FBlueprintEditorUtils::FindNewVariableIndex(Blueprint, InNewVarName);
     if (VarIndex != INDEX_NONE && VarIndex != VariableIndexInTS)
     {
-        if(Blueprint->NewVariables.IsValidIndex(VariableIndexInTS))
+        if (Blueprint->NewVariables.IsValidIndex(VariableIndexInTS))
         {
             Blueprint->NewVariables.Swap(VarIndex, VariableIndexInTS);
             VarIndex = VariableIndexInTS;
@@ -1180,7 +1180,9 @@ void UPEBlueprintAsset::AddMemberVariableWithMetaData(FName InNewVarName, FPEGra
         }
         else
         {
-            UE_LOG(PuertsEditorModule, Error, TEXT("The added variables have been deleted elsewhere, making it impossible to correctly adjust the variable order."))
+            UE_LOG(PuertsEditorModule, Error,
+                TEXT("The added variables have been deleted elsewhere, making it impossible to correctly adjust the variable "
+                     "order."))
         }
     }
     if (VarIndex != INDEX_NONE)

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -1169,7 +1169,7 @@ void UPEBlueprintAsset::AddMemberVariableWithMetaData(FName InNewVarName, FPEGra
         InHFLags = (static_cast<uint64>(InputFlags) >> 32);
     }
     AddMemberVariable(InNewVarName, InGraphPinType, InPinValueType, InLFlags, InHFLags, InLifetimeCondition);
-    const int32 VarIndex = FBlueprintEditorUtils::FindNewVariableIndex(Blueprint, InNewVarName);
+    int32 VarIndex = FBlueprintEditorUtils::FindNewVariableIndex(Blueprint, InNewVarName);
     if (VarIndex != INDEX_NONE && VarIndex != VariableIndexInTS)
     {
         if (Blueprint->NewVariables.IsValidIndex(VariableIndexInTS))

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -1172,9 +1172,16 @@ void UPEBlueprintAsset::AddMemberVariableWithMetaData(FName InNewVarName, FPEGra
     const int32 VarIndex = FBlueprintEditorUtils::FindNewVariableIndex(Blueprint, InNewVarName);
     if (VarIndex != INDEX_NONE && VarIndex != VariableIndexInTS)
     {
-        Blueprint->NewVariables.Swap(VarIndex, VariableIndexInTS);
-        VarIndex = VariableIndexInTS;
-        NeedSave = true;
+        if(Blueprint->NewVariables.IsValidIndex(VariableIndexInTS))
+        {
+            Blueprint->NewVariables.Swap(VarIndex, VariableIndexInTS);
+            VarIndex = VariableIndexInTS;
+            NeedSave = true;
+        }
+        else
+        {
+            UE_LOG(PuertsEditorModule, Error, TEXT("The added variables have been deleted elsewhere, making it impossible to correctly adjust the variable order."))
+        }
     }
     if (VarIndex != INDEX_NONE)
     {

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -1170,6 +1170,16 @@ void UPEBlueprintAsset::AddMemberVariableWithMetaData(FName InNewVarName, FPEGra
     }
     AddMemberVariable(InNewVarName, InGraphPinType, InPinValueType, InLFlags, InHFLags, InLifetimeCondition);
     const int32 VarIndex = FBlueprintEditorUtils::FindNewVariableIndex(Blueprint, InNewVarName);
+    if (VarIndex != INDEX_NONE && VarIndex != VariableIndexInTS)
+    {
+        Blueprint->NewVariables.Swap(VarIndex, VariableIndexInTS);
+        VarIndex = VariableIndexInTS;
+        NeedSave = true;
+    }
+    if (VarIndex != INDEX_NONE)
+    {
+        ++VariableIndexInTS;
+    }
     if (VarIndex == INDEX_NONE)
     {
         return;

--- a/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintAsset.h
+++ b/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintAsset.h
@@ -79,6 +79,9 @@ public:
     UPROPERTY()
     bool HasConstructor;
 
+    // Record the variable's location in the .ts file.
+    int32 VariableIndexInTS = 0;
+
     UFUNCTION(BlueprintCallable, Category = "PEBlueprintAsset")
     static bool Existed(const FString& InName, const FString& InPath);
 


### PR DESCRIPTION
蓝图中展示变量的顺序和ts中定义的不一样，在配置值时有时候会比较麻烦，故更改