### PR TITLE
[unreal]fix:修复删除uproperty中Property Specifiers不生效的问题

### DIFF
--- a/unreal/Puerts/Content/JavaScript/PuertsEditor/CodeAnalyze.js
+++ b/unreal/Puerts/Content/JavaScript/PuertsEditor/CodeAnalyze.js
@@ -997,9 +997,10 @@ function watch(configFilePath) {
                                     }
                                 });
                             }
-                            if (!hasDecorator(symbol.valueDeclaration, "edit_on_instance")) {
-                                flags = flags | BigInt(PropertyFlags.CPF_DisableEditOnInstance);
-                            }
+                            // Invalid code, only recognizes UPROPERTY UMETA, causing the DisableEditOnInstance flag to be added every time.
+                            // if (!hasDecorator(symbol.valueDeclaration, "edit_on_instance")) {
+                            //     flags = flags | BigInt(PropertyFlags.CPF_DisableEditOnInstance);
+                            // }
                             // bp.AddMemberVariable(symbol.getName(), propPinType.pinType, propPinType.pinValueType, Number(flags & 0xffffffffn), Number(flags >> 32n), cond);
                             bp.AddMemberVariableWithMetaData(symbol.getName(), propPinType.pinType, propPinType.pinValueType, Number(flags & 0xffffffffn), Number(flags >> 32n), cond, uemeta.compilePropertyMetaData(symbol));
                         }


### PR DESCRIPTION
修复问题：https://github.com/Tencent/puerts/issues/1682
问题原因：在bool UPEPropertyMetaData::Apply(FBPVariableDescription& Element) const函数中直接使用|=来增加flag而不删除已移除的flag
修复思路：合理的思路应该是计算出一个正确的新的flags代替原有的flags，而非直接使用|=来加上新的，各种flag计算和特殊处理也应该放在apply之前，这种思路主要要确保的是新flag计算正确，参考FBlueprintVarActionDetails类中的代码中set各种flag部分，发现除网络相关flag有特殊处理外其他并无特殊处理（在未更改的代码中就已经处理过了），可以认为现有的改动问题风险应该不大。
主要印象：原有的代码会保留蓝图添加变量默认增加的flag（参考这个函数FBlueprintEditorUtils::AddMemberVariable）默认添加的主要是(CPF_Edit | CPF_BlueprintVisible | CPF_DisableEditOnInstance) 但是这几个都是为了在蓝图中处理变量更加方便而处理的，而我们在写ts代码时应该与cpp中保持一致，所以并不保留蓝图默认添加的flag，这样带了的影响是原先代码没有EditAnywhere等属性说明符也能在编辑器中编辑，更改后则与cpp保持一致，应当使用EditAnywhere等flag后才能编辑，对于希望保留默认添加的变量只需在UPEBlueprintAsset::AddMemberVariable取消注释相关代码即可
其他更改说明：codeanalyze.js注释掉的代码，这段代码测试是无效的，导致每次都会默认添加一个DisableEditOnInstance的flag