### PR TITLE
[unreal]:增加对未能正确添加变量的情况进行提示

### DIFF
--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -42,6 +42,8 @@
 #include "Kismet2/ComponentEditorUtils.h"
 #include "Editor.h"
 #include "HAL/PlatformFileManager.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Misc/MessageDialog.h"
 
 #define LOCTEXT_NAMESPACE "UPEBlueprintAsset"
 
@@ -1080,8 +1082,22 @@ void UPEBlueprintAsset::AddMemberVariable(FName NewVarName, FPEGraphPinType InGr
     if (VarIndex == INDEX_NONE)
     {
         CanChangeCheck();
-        FBlueprintEditorUtils::AddMemberVariable(Blueprint, NewVarName, PinType);
-        NeedSave = true;
+        if (NewVarName == NAME_None)
+        {
+            FString Message = FString::Printf(TEXT("VariableName  is None, unable to add variable"));
+            FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(Message));
+        }
+        else if (FBlueprintEditorUtils::AddMemberVariable(Blueprint, NewVarName, PinType))
+        {
+            NeedSave = true;
+        }
+        else
+        {
+            FString Message = FString::Printf(
+                TEXT("Failed to add variable: %s. Please check if the parent class already has a variable with the same name."),
+                *NewVarName.ToString());
+            FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(Message));
+        }
     }
     else
     {


### PR DESCRIPTION
问题：如果在ts定义一个与父类同名的变量，编译看起来能正确通过没有报错提示，但实际上没有正确添加变量，造成排查麻烦，故增加对是否成功添加了变量的检测，并在失败时进行弹窗提示。