### PR TITLE
自动生命周期Delegate的owner被GC的时候ResetJsFunction 

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -2110,6 +2110,10 @@ void FJsEnvImpl::NotifyUObjectDeleted(const class UObjectBase* ObjectBase, int32
     {
         for (auto Callback : *CallbacksPtr)
         {
+            if (Callback.IsValid())
+            {
+                Callback.Get()->JsFunction.Reset();
+            }
             SysObjectRetainer.Release(Callback.Get());
         }
         AutoReleaseCallbacksMap.Remove((UObject*) ObjectBase);


### PR DESCRIPTION
避免JsEnv被GC的后，UDynamicDelegateProxy被GC导致的崩溃