### PR TITLE
wrapper添加 MakeConstVariable

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Public/ScriptBackend.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/ScriptBackend.hpp
@@ -36,6 +36,9 @@
         ::PUERTS_NAMESPACE::PropertyWrapper<PUERTS_NAMESPACE::PUERTS_BINDING_IMPL::API, decltype(M), M>::info()
 #define MakeVariable(M) MakeProperty(M)
 #define MakeReadonlyVariable(M) MakeReadonlyProperty(M)
+#define MakeConstVariable(M)                                                                                          \
+    &(::PUERTS_NAMESPACE::ConstVariableWrapper<PUERTS_NAMESPACE::PUERTS_BINDING_IMPL::API, decltype(M), M>::getter), nullptr, \
+        ::PUERTS_NAMESPACE::ConstVariableWrapper<PUERTS_NAMESPACE::PUERTS_BINDING_IMPL::API, decltype(M), M>::info()
 #define MakeFunction(M, ...)                                                                                                    \
     [](::PUERTS_NAMESPACE::PUERTS_BINDING_IMPL::API::CallbackInfoType info)                                                     \
     {                                                                                                                           \

--- a/unreal/Puerts/Source/JsEnv/Public/StaticCall.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/StaticCall.hpp
@@ -1457,6 +1457,25 @@ struct PropertyWrapper<API, Ret*, Variable>
         return CTypeInfoImpl<Ret, false>::get();
     }
 };
+template <typename API, typename Ret, Ret Variable>
+struct ConstVariableWrapper
+{
+    template <typename T>
+    using DecayTypeConverter = typename API::template Converter<typename internal::ConverterDecay<T>::type>;
+
+    static void getter(typename API::CallbackInfoType info)
+    {
+        auto context = API::GetContext(info);
+        API::SetReturn(info, DecayTypeConverter<Ret>::toScript(context, Variable));
+    }
+
+    static void setter(typename API::CallbackInfoType info) { }
+
+    static const CTypeInfo* info()
+    {
+        return CTypeInfoImpl<Ret, false>::get();
+    }
+};
 
 template <typename T, typename API, typename RegisterAPI>
 class ClassDefineBuilder


### PR DESCRIPTION
针对手机平台编译时，static const修饰的成员变量会报以下问题的解决方案：
![image](https://github.com/user-attachments/assets/37b7c00a-1df2-4406-9d0e-772664884a54)


使用方式：
```
    .Variable("VARIANT_MODE_POSTPROCESS", MakeConstVariable(Stage::VARIANT_MODE_POSTPROCESS))
```

相比MakeReadonlyVariable，不需要&取地址。