### PR TITLE
1.修复退出是由于互相依赖导致的crash问题;2.当C#抛出异常是可能会导致CleanupPapiEnvRef二次执行的问题

### DIFF
--- a/unity/Assets/core/upm/Editor/Resources/puerts/xil2cpp/Puerts_il2cpp.cpp.txt
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/xil2cpp/Puerts_il2cpp.cpp.txt
@@ -1953,12 +1953,19 @@ void CleanupPapiEnvRef(struct pesapi_ffi* apis, pesapi_env_ref envRef)
 {
     puerts::AutoValueScope ValueScope(apis, envRef);
     auto env = apis->get_env_from_ref(envRef);
-    auto jsEnvPrivate = (puerts::JsEnvPrivate*)apis->get_env_private(env);
-    jsEnvPrivate->CleanupPendingKillScriptObjects();
-    delete jsEnvPrivate;
-    apis->release_env_ref(envRef);
+    if (env)
+    {
+        auto jsEnvPrivate = (puerts::JsEnvPrivate*) apis->get_env_private(env);
+        jsEnvPrivate->CleanupPendingKillScriptObjects();
+        // delete jsEnvPrivate;
+        apis->release_env_ref(envRef);
+    }
 }
 
+void DestroyJSEnvPrivate(JsEnvPrivate* jsEnvPrivate)
+{
+    delete jsEnvPrivate;
+}
 }
 
 #ifdef __cplusplus
@@ -1983,6 +1990,7 @@ void InitialPuerts(pesapi_func_ptr* func_array)
     InternalCalls::Add("PuertsIl2cpp.NativeAPI::GetModuleExecutor(System.IntPtr,System.IntPtr,System.Type)", (Il2CppMethodPointer)puerts::GetModuleExecutor);
     InternalCalls::Add("PuertsIl2cpp.NativeAPI::InitialPapiEnvRef(System.IntPtr,System.IntPtr,System.Object,System.Reflection.MethodBase,System.Reflection.MethodBase)", (Il2CppMethodPointer)puerts::InitialPapiEnvRef);
     InternalCalls::Add("PuertsIl2cpp.NativeAPI::CleanupPapiEnvRef(System.IntPtr,System.IntPtr)", (Il2CppMethodPointer)puerts::CleanupPapiEnvRef);
+    InternalCalls::Add("PuertsIl2cpp.NativeAPI::DestroyJSEnvPrivate(System.IntPtr)", (Il2CppMethodPointer)puerts::DestroyJSEnvPrivate);
     InternalCalls::Add("Puerts.JSObject::GetJSObjectValue(System.IntPtr,System.String,System.Type)", (Il2CppMethodPointer)puerts::GetJSObjectValue);
     InternalCalls::Add("PuertsIl2cpp.NativeAPI::SetRegisterNoThrow(System.Reflection.MethodBase)", (Il2CppMethodPointer)puerts::SetRegisterNoThrow);
     pesapi_init(func_array);

--- a/unity/Assets/core/upm/Runtime/Src/IL2Cpp/JsEnv.cs
+++ b/unity/Assets/core/upm/Runtime/Src/IL2Cpp/JsEnv.cs
@@ -256,6 +256,8 @@ namespace Puerts
                 if (disposed) return;
                 PuertsIl2cpp.NativeAPI.CleanupPapiEnvRef(apis, nativePesapiEnv);
                 PuertsIl2cpp.NativeAPI.DestroyNativeJSEnv(nativeJsEnv);
+                PuertsIl2cpp.NativeAPI.DestroyJSEnvPrivate(nativeScriptObjectsRefsMgr);
+                nativeScriptObjectsRefsMgr = IntPtr.Zero;
                 disposed = true;
             }
             lock (jsEnvs)

--- a/unity/Assets/core/upm/Runtime/Src/IL2Cpp/Native/NativeAPI.cs
+++ b/unity/Assets/core/upm/Runtime/Src/IL2Cpp/Native/NativeAPI.cs
@@ -68,6 +68,12 @@ namespace PuertsIl2cpp
             throw new NotImplementedException();
         }
 
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static void DestroyJSEnvPrivate(IntPtr jsEnvPrivate)
+        {
+            throw new NotImplementedException();
+        }
+
         [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr CreateCSharpTypeInfo(string name, IntPtr type_id, IntPtr super_type_id, bool isValueType, bool isDelegate, string delegateSignature);
 


### PR DESCRIPTION
HelloWorld场景在一秒之后退出会触发crash