### PR TITLE
[unreal]对于原生cpp绑定，若未绑定构造函数，则在ts声明中加入abstract标记，可以在ts中尝试构造时提示报错

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/TemplateBindingGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/TemplateBindingGenerator.cpp
@@ -83,7 +83,17 @@ struct FGenImp
     {
         if (HasUENamespace(ClassDefinition->ScriptName))
             return;
-        Output << "    class " << ClassDefinition->ScriptName;
+
+        Output << "    ";
+
+        PUERTS_NAMESPACE::NamedFunctionInfo* ConstructorInfo = ClassDefinition->ConstructorInfos;
+        const bool IsNoConstructorInfos = !ConstructorInfo || !(ConstructorInfo->Name && ConstructorInfo->Type);
+        if (IsNoConstructorInfos)
+        {
+            Output << "abstract ";
+        }
+
+        Output << "class " << ClassDefinition->ScriptName;
         if (ClassDefinition->SuperTypeId)
         {
             Output << " extends " << PUERTS_NAMESPACE::FindClassByID(ClassDefinition->SuperTypeId)->ScriptName;
@@ -92,7 +102,6 @@ struct FGenImp
 
         TSet<FString> AddedFunctions;
 
-        PUERTS_NAMESPACE::NamedFunctionInfo* ConstructorInfo = ClassDefinition->ConstructorInfos;
         while (ConstructorInfo && ConstructorInfo->Name && ConstructorInfo->Type)
         {
             FStringBuffer Tmp;


### PR DESCRIPTION
相关issues: #1970

改动前即使没有构造函数的信息也能尝试构造
改动后在声明中加入abstract，不允许ts构造，但不影响从cpp中获得