### PR TITLE
fix: 完善宏定义修复普通dotnet平台下,生成的by ref like的相关绑定代码报错.

### DIFF
--- a/unity/Assets/core/upm/Editor/Src/Generator/Utils.cs
+++ b/unity/Assets/core/upm/Editor/Src/Generator/Utils.cs
@@ -227,7 +227,7 @@ namespace Puerts.Editor
                     FieldInfo fi = (mbi as FieldInfo);
                     if (
                         fi.FieldType.IsPointer
-#if UNITY_2021_2_OR_NEWER
+#if UNITY_2021_2_OR_NEWER || PUERTS_GENERAL || PUERTS_GENERAL_OSX
                         || fi.FieldType.IsByRefLike
 #endif
                     )
@@ -248,7 +248,7 @@ namespace Puerts.Editor
                     PropertyInfo pi = (mbi as PropertyInfo);
                     if (
                         pi.PropertyType.IsPointer
-#if UNITY_2021_2_OR_NEWER
+#if UNITY_2021_2_OR_NEWER || PUERTS_GENERAL || PUERTS_GENERAL_OSX
                         || pi.PropertyType.IsByRefLike
 #endif
                     )
@@ -280,7 +280,7 @@ namespace Puerts.Editor
                         return true;
                     }
                     if (mi.ReturnType.IsPointer
-#if UNITY_2021_2_OR_NEWER
+#if UNITY_2021_2_OR_NEWER || PUERTS_GENERAL || PUERTS_GENERAL_OSX
                         || mi.ReturnType.IsByRefLike
 #endif
                     )
@@ -302,7 +302,7 @@ namespace Puerts.Editor
                     MethodBase mb = mbi as MethodBase;
                     if (
                         mb.GetParameters().Any(pInfo => pInfo.ParameterType.IsPointer
-#if UNITY_2021_2_OR_NEWER
+#if UNITY_2021_2_OR_NEWER || PUERTS_GENERAL || PUERTS_GENERAL_OSX
                         || pInfo.ParameterType.IsByRefLike
 #endif
                     ))


### PR DESCRIPTION
在使用普通dotnet项目中生成wrapper后出现了报错. 发现是历史问题, 但是目前只在unity下通过宏定义取消生成相关绑定修复了该问题.  
报错信息:
![image](https://github.com/user-attachments/assets/32bcf3b2-ffca-446b-b025-11f435a0ea97)
