### PR TITLE
WebGL CLI/index.js 避免重复npm i

### DIFF
--- a/unity/Assets/webgl/upm/Cli/Javascripts~/index.js
+++ b/unity/Assets/webgl/upm/Cli/Javascripts~/index.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 const cp = require('child_process');
+const path = require('path');
 
-if (!fs.existsSync(__dirname + 'node_modules')) {
+if (!fs.existsSync(path.join(__dirname, 'node_modules'))) {
   cp.exec('npm i', { cwd: __dirname }, (error, stdout, stderr) => {
     if (error) {
       console.error('Error in installing dependency ', error);


### PR DESCRIPTION
实测在windows下会重复npm i安装，原因是因为 __dirname + “node_modules” 缺少 "/"，应该是__dirname + “/node_modules” 。 改用path.join拼接出node_modules文件夹路径