### PR TITLE
适配pixui

### DIFF
--- a/unity/cli/cmd.mjs
+++ b/unity/cli/cmd.mjs
@@ -32,6 +32,7 @@ program
             .choices(["Release", "Debug"])
     )
     .option("--backend <backend>", "the JS backend will be used", "v8_9.4")
+    .option('--rebuild', 'clean and rebuild')
     .option('-ws, --websocket <number>', 'with websocket support')
     .option('-G, --generator <generator-name>', 'cmake generator name')
     .option('-ts, --thread_safe', 'thread safe')

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -62,8 +62,18 @@ const platformCompileConfig = {
                 const API = options.backend.indexOf('node') !== -1 ? 'android-24' : (options.backend.indexOf('10.6.194') !== -1 ? 'android-23' : 'android-21');
                 const ABI = 'armeabi-v7a';
                 const TOOLCHAIN_NAME = 'arm-linux-androideabi-4.9';
+                let MAKE;
+                if(process.platform == "win32"){
+                    MAKE = `${NDK}/prebuilt/windows-x86_64/bin/make.exe`
+                }
+                else if(process.platform == "darwin"){
+                    MAKE = `${NDK}/prebuilt/darwin-x86_64/bin/make`
+                }
+                else{
+                    MAKE = `${NDK}/prebuilt/linux-x86_64/bin/make`
+                }
 
-                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME}`).code);
+                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME} -DCMAKE_MAKE_PROGRAM=${MAKE} -G"Unix Makefiles"`).code);
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
@@ -79,8 +89,18 @@ const platformCompileConfig = {
                 const API = options.backend.indexOf('node') !== -1 ? 'android-24' : (options.backend.indexOf('10.6.194') !== -1 ? 'android-23' : 'android-21');
                 const ABI = 'arm64-v8a';
                 const TOOLCHAIN_NAME = 'arm-linux-androideabi-clang';
+                let MAKE;
+                if(process.platform == "win32"){
+                    MAKE = `${NDK}/prebuilt/windows-x86_64/bin/make.exe`
+                }
+                else if(process.platform == "darwin"){
+                    MAKE = `${NDK}/prebuilt/darwin-x86_64/bin/make`
+                }
+                else{
+                    MAKE = `${NDK}/prebuilt/linux-x86_64/bin/make`
+                }
 
-                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME}`).code);
+                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME} -DCMAKE_MAKE_PROGRAM=${MAKE} -G"Unix Makefiles"`).code);
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
@@ -96,8 +116,18 @@ const platformCompileConfig = {
                 const API = options.backend.indexOf('node') !== -1 ? 'android-24' : (options.backend.indexOf('10.6.194') !== -1 ? 'android-23' : 'android-21');
                 const ABI = 'x86_64';
                 const TOOLCHAIN_NAME = 'x86_64-4.9';
+                let MAKE;
+                if(process.platform == "win32"){
+                    MAKE = `${NDK}/prebuilt/windows-x86_64/bin/make.exe`
+                }
+                else if(process.platform == "darwin"){
+                    MAKE = `${NDK}/prebuilt/darwin-x86_64/bin/make`
+                }
+                else{
+                    MAKE = `${NDK}/prebuilt/linux-x86_64/bin/make`
+                }
 
-                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME}`).code);
+                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME} -DCMAKE_MAKE_PROGRAM=${MAKE} -G"Unix Makefiles"`).code);
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
@@ -115,9 +145,11 @@ const platformCompileConfig = {
                 if (!NDK) throw new Error("please set OHOS_NDK environment variable first!");
                 const ABI = 'armeabi-v7a';
                 const cmake_bin_path = `${NDK}/build-tools/cmake/bin/cmake`;
+                const ninja_bin_path = `${NDK}/build-tools/cmake/bin/ninja`;
+                const toolchain_file = `${NDK}/build/cmake/ohos.toolchain.cmake`;
 
-                assert.equal(0, exec(`${cmake_bin_path} ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B${CMAKE_BUILD_PATH}  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/ohos.toolchain.cmake`).code);
-                assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" ${cmakeDArgs} -GNinja -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B"${CMAKE_BUILD_PATH}"  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}" -DCMAKE_MAKE_PROGRAM="${ninja_bin_path}"`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
                     return [`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`];
@@ -132,9 +164,11 @@ const platformCompileConfig = {
                 if (!NDK) throw new Error("please set OHOS_NDK environment variable first!");
                 const ABI = 'arm64-v8a';
                 const cmake_bin_path = `${NDK}/build-tools/cmake/bin/cmake`;
+                const ninja_bin_path = `${NDK}/build-tools/cmake/bin/ninja`;
+                const toolchain_file = `${NDK}/build/cmake/ohos.toolchain.cmake`;
 
-                assert.equal(0, exec(`${cmake_bin_path} ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B${CMAKE_BUILD_PATH}  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/ohos.toolchain.cmake`).code);
-                assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" ${cmakeDArgs} -GNinja -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B"${CMAKE_BUILD_PATH}"  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}" -DCMAKE_MAKE_PROGRAM="${ninja_bin_path}"`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
                     return [`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`];

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -327,6 +327,10 @@ async function runPuertsMake(cwd, options) {
     const linkD = (BackendConfig['link-libraries'][options.platform]?.[options.arch] || []).join(';');
     const incD = (BackendConfig.include || []).join(';');
 
+    if (options.rebuild && existsSync(CMAKE_BUILD_PATH)) {
+        rm('-rf', CMAKE_BUILD_PATH);
+    }
+
     mkdir('-p', CMAKE_BUILD_PATH);
     mkdir('-p', OUTPUT_PATH);
     const DArgsName = ['-DBACKEND_DEFINITIONS=', '-DBACKEND_LIB_NAMES=', '-DBACKEND_INC_NAMES='];

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -232,7 +232,11 @@ const platformCompileConfig = {
                 cd("..");
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
-                return `${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`;
+                let libs = [`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`];
+                if (existsSync(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`)) {
+                    libs.push(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`);
+                }
+                return libs;
             }
         },
         'ia32': {
@@ -245,7 +249,11 @@ const platformCompileConfig = {
                 cd("..");
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
-                return `${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`;
+                let libs = [`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`];
+                if (existsSync(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`)) {
+                    libs.push(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`);
+                }
+                return libs;
             }
         }
     },

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -381,6 +381,11 @@ async function runPuertsMake(cwd, options) {
     options.websocket = options.websocket || 0;
     CmakeDArgs += ` -DWITH_WEBSOCKET=${options.websocket}`;
 
+
+    for(let opt in BackendConfig?.cmake_options){
+        CmakeDArgs = CmakeDArgs.concat(` ${BackendConfig?.cmake_options[opt]}`)
+    }
+
     var outputFile = BuildConfig.hook(
         CMAKE_BUILD_PATH,
         options,

--- a/unity/native_src/Inc/BackendEnv.h
+++ b/unity/native_src/Inc/BackendEnv.h
@@ -180,6 +180,8 @@ namespace PUERTS_NAMESPACE
         char* module_normalize(JSContext *ctx, const char *base_name, const char *name, void* opaque);
     
         JSValue ExecuteModule(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv, int magic, JSValue *func_data);
+
+        JSValue ExternalExecuteModule(JSContext* ctx, JSValueConst this_val, int argc, JSValueConst* argv, int magic, JSValue* func_data);
 #endif
     }
 }

--- a/unity/native_src/Src/JSEngine.cpp
+++ b/unity/native_src/Src/JSEngine.cpp
@@ -249,9 +249,14 @@ namespace PUERTS_NAMESPACE
     {
         if (ModuleExecutor == nullptr)
         {
-            bool success = Eval(ExecuteModuleJSCode, "__puer_execute__.mjs");
-            if (!success) return nullptr;
-            
+#if QJS_BACKEND
+        	/* while quickjs external runtime, the module executor uses ExternalExecuteModule, donot need to eval __puer_execute__.mjs */
+        	if (!MainIsolate->is_external_runtime_)
+#endif
+        	{
+            	bool success = Eval(ExecuteModuleJSCode, "__puer_execute__.mjs");
+           		if (!success) return nullptr;
+        	}
 #ifdef THREAD_SAFE
             v8::Locker Locker(MainIsolate);
 #endif

--- a/unity/native_src/backend-quickjs/src/v8-impl.cc
+++ b/unity/native_src/backend-quickjs/src/v8-impl.cc
@@ -668,12 +668,9 @@ Local<Set> Set::New(Isolate* isolate) {
     return Local<Set>(set);
 }
 
-static std::vector<uint8_t> dummybuffer;
-
 Local<ArrayBuffer> ArrayBuffer::New(Isolate* isolate, size_t byte_length) {
     ArrayBuffer *ab = isolate->Alloc<ArrayBuffer>();
-    if (dummybuffer.size() < byte_length) dummybuffer.resize(byte_length, 0);
-    ab->value_ = JS_NewArrayBufferCopy(isolate->current_context_->context_, dummybuffer.data(), byte_length);
+    ab->value_ = JS_NewArrayBufferCopy(isolate->current_context_->context_, nullptr, byte_length);
     return Local<ArrayBuffer>(ab);
 }
 


### PR DESCRIPTION
1. 增加--rebuild构建选项，构建前删除旧工程，方便出包时不受cmake缓存影响
2. 修改cmake对android\ohos的工具指定，减少受到构建环境的影响
3. 收集windows pdb产物
4. 支持从backends.json中定义cmake define
5. v8-impl.cc中移除对quickjs-atom.h的依赖
    使用external runtime或者动态链接quickjs时，使用quickjs-atom.h应该保持跟动态库一致的编译参数，或者只使用quickjs的公开api使用。
6. 去除v8-impl.cc中ArrayBuffer:New中的dummybuffer，避免它造成不必要的常驻内存开销(这个参数为nullptr是没有影响的)
7. 修改BackendEnv.cpp，在external runtime时模块解析由外部虚拟机负责