### PR TITLE
Pixui pr

### DIFF
--- a/unity/cli/cmd.mjs
+++ b/unity/cli/cmd.mjs
@@ -32,6 +32,7 @@ program
             .choices(["Release", "Debug"])
     )
     .option("--backend <backend>", "the JS backend will be used", "v8_9.4")
+    .option('--rebuild', 'clean and rebuild')
     .option('-ws, --websocket <number>', 'with websocket support')
     .option('-G, --generator <generator-name>', 'cmake generator name')
     .option('-ts, --thread_safe', 'thread safe')

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -62,8 +62,18 @@ const platformCompileConfig = {
                 const API = options.backend.indexOf('node') !== -1 ? 'android-24' : (options.backend.indexOf('10.6.194') !== -1 ? 'android-23' : 'android-21');
                 const ABI = 'armeabi-v7a';
                 const TOOLCHAIN_NAME = 'arm-linux-androideabi-4.9';
+                let MAKE;
+                if(process.platform == "win32"){
+                    MAKE = `${NDK}/prebuilt/windows-x86_64/bin/make.exe`
+                }
+                else if(process.platform == "darwin"){
+                    MAKE = `${NDK}/prebuilt/darwin-x86_64/bin/make`
+                }
+                else{
+                    MAKE = `${NDK}/prebuilt/linux-x86_64/bin/make`
+                }
 
-                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME}`).code);
+                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME} -DCMAKE_MAKE_PROGRAM=${MAKE} -G"Unix Makefiles"`).code);
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
@@ -79,8 +89,18 @@ const platformCompileConfig = {
                 const API = options.backend.indexOf('node') !== -1 ? 'android-24' : (options.backend.indexOf('10.6.194') !== -1 ? 'android-23' : 'android-21');
                 const ABI = 'arm64-v8a';
                 const TOOLCHAIN_NAME = 'arm-linux-androideabi-clang';
+                let MAKE;
+                if(process.platform == "win32"){
+                    MAKE = `${NDK}/prebuilt/windows-x86_64/bin/make.exe`
+                }
+                else if(process.platform == "darwin"){
+                    MAKE = `${NDK}/prebuilt/darwin-x86_64/bin/make`
+                }
+                else{
+                    MAKE = `${NDK}/prebuilt/linux-x86_64/bin/make`
+                }
 
-                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME}`).code);
+                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME} -DCMAKE_MAKE_PROGRAM=${MAKE} -G"Unix Makefiles"`).code);
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
@@ -96,8 +116,18 @@ const platformCompileConfig = {
                 const API = options.backend.indexOf('node') !== -1 ? 'android-24' : (options.backend.indexOf('10.6.194') !== -1 ? 'android-23' : 'android-21');
                 const ABI = 'x86_64';
                 const TOOLCHAIN_NAME = 'x86_64-4.9';
+                let MAKE;
+                if(process.platform == "win32"){
+                    MAKE = `${NDK}/prebuilt/windows-x86_64/bin/make.exe`
+                }
+                else if(process.platform == "darwin"){
+                    MAKE = `${NDK}/prebuilt/darwin-x86_64/bin/make`
+                }
+                else{
+                    MAKE = `${NDK}/prebuilt/linux-x86_64/bin/make`
+                }
 
-                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME}`).code);
+                assert.equal(0, exec(`cmake ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DANDROID_ABI=${ABI} -H. -B${CMAKE_BUILD_PATH} -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_TOOLCHAIN=clang -DANDROID_TOOLCHAIN_NAME=${TOOLCHAIN_NAME} -DCMAKE_MAKE_PROGRAM=${MAKE} -G"Unix Makefiles"`).code);
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
@@ -115,9 +145,11 @@ const platformCompileConfig = {
                 if (!NDK) throw new Error("please set OHOS_NDK environment variable first!");
                 const ABI = 'armeabi-v7a';
                 const cmake_bin_path = `${NDK}/build-tools/cmake/bin/cmake`;
+                const ninja_bin_path = `${NDK}/build-tools/cmake/bin/ninja`;
+                const toolchain_file = `${NDK}/build/cmake/ohos.toolchain.cmake`;
 
-                assert.equal(0, exec(`${cmake_bin_path} ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B${CMAKE_BUILD_PATH}  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/ohos.toolchain.cmake`).code);
-                assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" ${cmakeDArgs} -GNinja -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B"${CMAKE_BUILD_PATH}"  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}" -DCMAKE_MAKE_PROGRAM="${ninja_bin_path}"`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
                     return [`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`];
@@ -132,9 +164,11 @@ const platformCompileConfig = {
                 if (!NDK) throw new Error("please set OHOS_NDK environment variable first!");
                 const ABI = 'arm64-v8a';
                 const cmake_bin_path = `${NDK}/build-tools/cmake/bin/cmake`;
+                const ninja_bin_path = `${NDK}/build-tools/cmake/bin/ninja`;
+                const toolchain_file = `${NDK}/build/cmake/ohos.toolchain.cmake`;
 
-                assert.equal(0, exec(`${cmake_bin_path} ${cmakeDArgs} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B${CMAKE_BUILD_PATH}  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/ohos.toolchain.cmake`).code);
-                assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" ${cmakeDArgs} -GNinja -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DJS_ENGINE=${options.backend} -DCMAKE_BUILD_TYPE=${options.config} -DOHOS_ARCH=${ABI} -H. -B"${CMAKE_BUILD_PATH}"  -DOHOS_PLATFORM=OHOS -DCMAKE_TOOLCHAIN_FILE="${toolchain_file}" -DCMAKE_MAKE_PROGRAM="${ninja_bin_path}"`).code);
+                assert.equal(0, exec(`"${cmake_bin_path}" --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
                 if (existsSync(`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`))
                     return [`${CMAKE_BUILD_PATH}/lib${cmakeAddedLibraryName}.a`];

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -327,6 +327,10 @@ async function runPuertsMake(cwd, options) {
     const linkD = (BackendConfig['link-libraries'][options.platform]?.[options.arch] || []).join(';');
     const incD = (BackendConfig.include || []).join(';');
 
+    if (options.rebuild && existsSync(CMAKE_BUILD_PATH)) {
+        rm('-rf', CMAKE_BUILD_PATH);
+    }
+
     mkdir('-p', CMAKE_BUILD_PATH);
     mkdir('-p', OUTPUT_PATH);
     const DArgsName = ['-DBACKEND_DEFINITIONS=', '-DBACKEND_LIB_NAMES=', '-DBACKEND_INC_NAMES='];

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -232,7 +232,11 @@ const platformCompileConfig = {
                 cd("..");
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
-                return `${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`;
+                let libs = [`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`];
+                if (existsSync(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`)) {
+                    libs.push(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`);
+                }
+                return libs;
             }
         },
         'ia32': {
@@ -245,7 +249,11 @@ const platformCompileConfig = {
                 cd("..");
                 assert.equal(0, exec(`cmake --build ${CMAKE_BUILD_PATH} --config ${options.config}`).code);
 
-                return `${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`;
+                let libs = [`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.dll`];
+                if (existsSync(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`)) {
+                    libs.push(`${CMAKE_BUILD_PATH}/${options.config}/${cmakeAddedLibraryName}.pdb`);
+                }
+                return libs;
             }
         }
     },

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -381,6 +381,11 @@ async function runPuertsMake(cwd, options) {
     options.websocket = options.websocket || 0;
     CmakeDArgs += ` -DWITH_WEBSOCKET=${options.websocket}`;
 
+
+    for(let opt in BackendConfig?.cmake_options){
+        CmakeDArgs = CmakeDArgs.concat(` ${BackendConfig?.cmake_options[opt]}`)
+    }
+
     var outputFile = BuildConfig.hook(
         CMAKE_BUILD_PATH,
         options,

--- a/unity/native_src/backend-quickjs/src/v8-impl.cc
+++ b/unity/native_src/backend-quickjs/src/v8-impl.cc
@@ -670,12 +670,9 @@ Local<Set> Set::New(Isolate* isolate) {
     return Local<Set>(set);
 }
 
-static std::vector<uint8_t> dummybuffer;
-
 Local<ArrayBuffer> ArrayBuffer::New(Isolate* isolate, size_t byte_length) {
     ArrayBuffer *ab = isolate->Alloc<ArrayBuffer>();
-    if (dummybuffer.size() < byte_length) dummybuffer.resize(byte_length, 0);
-    ab->value_ = JS_NewArrayBufferCopy(isolate->current_context_->context_, dummybuffer.data(), byte_length);
+    ab->value_ = JS_NewArrayBufferCopy(isolate->current_context_->context_, nullptr, byte_length);
     return Local<ArrayBuffer>(ab);
 }
 

--- a/unity/native_src/backend-quickjs/src/v8-impl.cc
+++ b/unity/native_src/backend-quickjs/src/v8-impl.cc
@@ -8,15 +8,6 @@ PRAGMA_ENABLE_UNDEFINED_IDENTIFIER_WARNINGS
 #include<cstring>
 #include <algorithm>
 
-enum
-{
-    JS_ATOM_NULL_,
-#define DEF(name, str) JS_ATOM_##name,
-#include "quickjs-atom.h"
-#undef DEF
-    JS_ATOM_END,
-};
-
 #ifndef PUERTS_IS_ARRAYBUFFER
     #define PUERTS_IS_ARRAYBUFFER JS_IsArrayBuffer
 #endif
@@ -232,8 +223,10 @@ Local<Value> Exception::Error(Local<String> message) {
     Value* val = isolate->Alloc<Value>();
     JSContext* ctx = isolate->current_context_->context_;
     val->value_ = JS_NewError(ctx);
-    JS_DefinePropertyValue(ctx, val->value_, JS_ATOM_message, JS_NewString(ctx, *String::Utf8Value(isolate, message)),
+    JSAtom messageAtom = JS_NewAtom(ctx, "message");
+    JS_DefinePropertyValue(ctx, val->value_, messageAtom, JS_NewString(ctx, *String::Utf8Value(isolate, message)),
                            JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE);
+    JS_FreeAtom(ctx, messageAtom);
     return Local<Value>(val);
 }
 
@@ -991,7 +984,9 @@ MaybeLocal<Object> ObjectTemplate::NewInstance(Local<Context> context)
     Object* obj = context->GetIsolate()->Alloc<Object>();
     if (constructor_template_) {
         JSValue func = constructor_template_ ->GetFunction(context).ToLocalChecked()->value_;
-        JSValue proto = JS_GetProperty(context->context_, func, JS_ATOM_prototype);
+        JSAtom prototypeAtom = JS_NewAtom(context->context_, "prototype");
+        JSValue proto = JS_GetProperty(context->context_, func, prototypeAtom);
+        JS_FreeAtom(context->context_, prototypeAtom);
         obj->value_ = JS_NewObjectProtoClass(context->context_, proto, context->GetIsolate()->class_id_);
         JS_FreeValue(context->context_, proto);
         size_t size = sizeof(ObjectUserData) + sizeof(void*) * (internal_field_count_ - 1);
@@ -1082,7 +1077,9 @@ MaybeLocal<Function> FunctionTemplate::GetFunction(Local<Context> context) {
         callbackInfo.isConstructCall = (bool)JS_ToBool(ctx, func_data[3]);
         
         if (callbackInfo.isConstructCall && internal_field_count > 0) {
-            JSValue proto = JS_GetProperty(ctx, this_val, JS_ATOM_prototype);
+            JSAtom prototypeAtom = JS_NewAtom(ctx, "prototype");
+            JSValue proto = JS_GetProperty(ctx, this_val, prototypeAtom);
+            JS_FreeAtom(ctx, prototypeAtom);
             callbackInfo.this_ = JS_NewObjectProtoClass(ctx, proto, isolate->class_id_);
             JS_FreeValue(ctx, proto);
             size_t size = sizeof(ObjectUserData) + sizeof(void*) * (internal_field_count - 1);
@@ -1109,10 +1106,11 @@ MaybeLocal<Function> FunctionTemplate::GetFunction(Local<Context> context) {
     }, 0, 0, 4, &func_data[0]);
     
     auto aname = JS_NewAtom(context->context_, name_.c_str());
+    JSAtom nameAtom = JS_NewAtom(context->context_, "name");
     JS_DefinePropertyValue( 
         context->context_, 
         func, 
-        JS_ATOM_name,
+        nameAtom,
         JS_AtomToString(context->context_, aname), 
         JS_PROP_CONFIGURABLE
     );
@@ -1131,7 +1129,9 @@ MaybeLocal<Function> FunctionTemplate::GetFunction(Local<Context> context) {
         
         if (!parent_.IsEmpty()) {
             Local<Function> parent_func = parent_->GetFunction(context).ToLocalChecked();
-            JSValue parent_proto = JS_GetProperty(context->context_, parent_func->value_, JS_ATOM_prototype);
+            JSAtom prototypeAtom = JS_NewAtom(context->context_, "prototype");
+            JSValue parent_proto = JS_GetProperty(context->context_, parent_func->value_, prototypeAtom);
+            JS_FreeAtom(context->context_, prototypeAtom);
             JS_SetPrototype(context->context_, proto, parent_proto);
             JS_FreeValue(context->context_, parent_proto);
         }
@@ -1313,7 +1313,9 @@ Local<Array> Array::New(Isolate* isolate) {
 
 uint32_t Array::Length() const {
     auto context = Isolate::current_->GetCurrentContext()->context_;
-    auto len = JS_GetProperty(context, value_, JS_ATOM_length);
+    JSAtom lengthAtom = JS_NewAtom(context, "length");
+    auto len = JS_GetProperty(context, value_, lengthAtom);
+    JS_FreeAtom(context, lengthAtom);
     if (JS_IsException(len)) {
         return 0;
     }
@@ -1362,7 +1364,9 @@ Local<Value> TryCatch::Exception() const {
 MaybeLocal<Value> TryCatch::StackTrace(Local<Context> context) const {
     auto str = context->GetIsolate()->Alloc<String>();
     JSValue ex = isolate_->hasPendingException_ ?  isolate_->pendingException_ : catched_;
-    str->value_ = JS_GetProperty(isolate_->current_context_->context_, ex, JS_ATOM_stack);;
+    JSAtom stackAtom = JS_NewAtom(context->context_, "stack");
+    str->value_ = JS_GetProperty(isolate_->current_context_->context_, ex, stackAtom);;
+    JS_FreeAtom(context->context_, stackAtom);
     return MaybeLocal<Value>(Local<String>(str));
 }
 
@@ -1370,7 +1374,9 @@ MaybeLocal<Value> TryCatch::StackTrace(
         Local<Context> context, Local<Value> exception) {
     auto isolate_ = context->GetIsolate();
     auto str = isolate_->Alloc<String>();
-    str->value_ = JS_GetProperty(isolate_->current_context_->context_, exception->value_, JS_ATOM_stack);
+    JSAtom stackAtom = JS_NewAtom(context->context_, "stack");
+    str->value_ = JS_GetProperty(isolate_->current_context_->context_, exception->value_, stackAtom);
+    JS_FreeAtom(context->context_, stackAtom);
     return MaybeLocal<Value>(Local<String>(str));
 }
     


### PR DESCRIPTION
1. 增加--rebuild构建选项，构建前删除旧工程，方便出包时不受cmake缓存影响
2. 修改cmake对android\ohos的工具指定，减少受到构建环境的影响
3. 收集windows pdb产物
4. 支持从backends.json中定义cmake define
5. v8-impl.cc中移除对quickjs-atom.h的依赖
    使用external runtime或者动态链接quickjs时，使用quickjs-atom.h应该保持跟动态库一致的编译参数，或者只使用quickjs的公开api使用。
6. 去除v8-impl.cc中ArrayBuffer:New中的dummybuffer，避免它造成不必要的常驻内存开销(这个参数为nullptr是没有影响的)