### PR TITLE
[unity]feat: 增加--rebuild选项，在构建时先删除旧工程，避免构建时被cmake缓存影响

### DIFF
--- a/unity/cli/cmd.mjs
+++ b/unity/cli/cmd.mjs
@@ -32,6 +32,7 @@ program
             .choices(["Release", "Debug"])
     )
     .option("--backend <backend>", "the JS backend will be used", "v8_9.4")
+    .option('--rebuild', 'clean and rebuild')
     .option('-ws, --websocket <number>', 'with websocket support')
     .option('-G, --generator <generator-name>', 'cmake generator name')
     .option('-ts, --thread_safe', 'thread safe')

--- a/unity/cli/make.mjs
+++ b/unity/cli/make.mjs
@@ -327,6 +327,10 @@ async function runPuertsMake(cwd, options) {
     const linkD = (BackendConfig['link-libraries'][options.platform]?.[options.arch] || []).join(';');
     const incD = (BackendConfig.include || []).join(';');
 
+    if (options.rebuild && existsSync(CMAKE_BUILD_PATH)) {
+        rm('-rf', CMAKE_BUILD_PATH);
+    }
+
     mkdir('-p', CMAKE_BUILD_PATH);
     mkdir('-p', OUTPUT_PATH);
     const DArgsName = ['-DBACKEND_DEFINITIONS=', '-DBACKEND_LIB_NAMES=', '-DBACKEND_INC_NAMES='];


### PR DESCRIPTION
增加--rebuild选项，在构建时先删除旧工程，避免构建时被cmake缓存影响