### PR TITLE
[unity]fix: 去除ArrayBuffer::New依赖的dummybuffer，减少其造成的常驻内存残留

### DIFF
--- a/unity/native_src/backend-quickjs/src/v8-impl.cc
+++ b/unity/native_src/backend-quickjs/src/v8-impl.cc
@@ -670,12 +670,9 @@ Local<Set> Set::New(Isolate* isolate) {
     return Local<Set>(set);
 }
 
-static std::vector<uint8_t> dummybuffer;
-
 Local<ArrayBuffer> ArrayBuffer::New(Isolate* isolate, size_t byte_length) {
     ArrayBuffer *ab = isolate->Alloc<ArrayBuffer>();
-    if (dummybuffer.size() < byte_length) dummybuffer.resize(byte_length, 0);
-    ab->value_ = JS_NewArrayBufferCopy(isolate->current_context_->context_, dummybuffer.data(), byte_length);
+    ab->value_ = JS_NewArrayBufferCopy(isolate->current_context_->context_, nullptr, byte_length);
     return Local<ArrayBuffer>(ab);
 }
 


### PR DESCRIPTION
fix: 去除ArrayBuffer::New依赖的dummybuffer，减少其造成的常驻内存残留