### PR TITLE
[unity]fix: 生成dts时，过滤拥有ref+pointer类型参数的函数

### DIFF
--- a/unity/Assets/core/upm/Editor/Src/Generator/Utils.cs
+++ b/unity/Assets/core/upm/Editor/Src/Generator/Utils.cs
@@ -336,6 +336,7 @@ namespace Puerts.Editor
                     MethodBase mb = mbi as MethodBase;
                     if (
                         mb.GetParameters().Any(pInfo => pInfo.ParameterType.IsPointer
+                        || (pInfo.ParameterType.IsByRef && pInfo.ParameterType.GetElementType().IsPointer)
 #if UNITY_2021_2_OR_NEWER || PUERTS_GENERAL || PUERTS_GENERAL_OSX
                         || pInfo.ParameterType.IsByRefLike
 #endif


### PR DESCRIPTION
fix: 生成dts时，过滤拥有ref+pointer类型参数的函数