### PR TITLE
[unreal] 1.低版本升级到新版本时 删除历史插件文件里残留的ue.d.ts和ue_bp.d.ts避免覆盖

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -415,10 +415,15 @@ void FTypeScriptDeclarationGenerator::GenTypeScriptDeclaration(bool InGenStruct,
     End();
 
     IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
-    PlatformFile.CopyDirectoryTree(*(FPaths::ProjectDir() / TEXT("Typing")),
-        *(IPluginManager::Get().FindPlugin("Puerts")->GetBaseDir() / TEXT("Typing")), false);
-    PlatformFile.CopyDirectoryTree(*(FPaths::ProjectContentDir() / TEXT("JavaScript")),
-        *(IPluginManager::Get().FindPlugin("Puerts")->GetBaseDir() / TEXT("Content") / TEXT("JavaScript")), true);
+    // 删除旧版本提交到Plugin的ue/ue_bp d.ts 避免残留污染编译
+    FString PuertsBaseDir = IPluginManager::Get().FindPlugin("Puerts")->GetBaseDir();
+    PlatformFile.DeleteFile(*(PuertsBaseDir / TEXT("Typing/ue/ue.d.ts")));
+    PlatformFile.DeleteFile(*(PuertsBaseDir / TEXT("Typing/ue/ue_bp.d.ts")));
+
+    FString ProjectTypingDir = (FPaths::ProjectDir() / TEXT("Typing"));
+    PlatformFile.CopyDirectoryTree(*ProjectTypingDir, *(PuertsBaseDir / TEXT("Typing")), false);
+    PlatformFile.CopyDirectoryTree(
+        *(FPaths::ProjectContentDir() / TEXT("JavaScript")), *(PuertsBaseDir / TEXT("Content") / TEXT("JavaScript")), true);
 
     const FString UEDeclarationFilePath = FPaths::ProjectDir() / TEXT("Typing/ue/ue.d.ts");
 
@@ -1678,7 +1683,7 @@ public:
 
                     for (auto& Arg : Args)
                     {
-                        if (Arg.ToUpper().Equals(TEXT("FULL")))
+                        if (Arg.ToUpper().Contains(TEXT("FULL")))
                         {
                             GenFull = true;
                         }


### PR DESCRIPTION
2.兼容gen full -full