### PR TITLE
增加对低版本python编译的支持适配(只验证了python3.10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode
+unity/native/papi-python/build_linux_x64_papi-python_debug

--- a/unity/native/papi-python/source/PapiPythonImpl.cpp
+++ b/unity/native/papi-python/source/PapiPythonImpl.cpp
@@ -721,7 +721,18 @@ pesapi_value pesapi_call_function(
     else
     {
         auto scope = getCurrentScope(state);
+#if PY_VERSION_HEX >= 0x030B0000
         scope->setCaughtException(PyErr_GetRaisedException());
+#else
+        {
+            PyObject *type = nullptr, *value = nullptr, *tb = nullptr;
+            PyErr_Fetch(&type, &value, &tb);
+            PyObject *exc = value ? value : type;
+            if (exc) Py_XINCREF(exc);
+            PyErr_Restore(type, value, tb);
+            scope->setCaughtException(exc);
+        }
+#endif
         return nullptr;
     }
 }
@@ -742,7 +753,18 @@ pesapi_value pesapi_eval(pesapi_env env, const uint8_t* code, size_t code_size, 
         }
     }
     auto scope = getCurrentScope(state);
+#if PY_VERSION_HEX >= 0x030B0000
     scope->setCaughtException(PyErr_GetRaisedException());
+#else
+    {
+        PyObject *type = nullptr, *value = nullptr, *tb = nullptr;
+        PyErr_Fetch(&type, &value, &tb);
+        PyObject *exc = value ? value : type;
+        if (exc) Py_XINCREF(exc);
+        PyErr_Restore(type, value, tb);
+        scope->setCaughtException(exc);
+    }
+#endif
     return nullptr;
 }
 


### PR DESCRIPTION
### 1. 增加适配
在项目中识别到的python版本较低时对`PyErr_GetRaisedException()`使用等价的语句进行替换执行，为低版本的python提供一定的支持

### 2. 修改gitignore
防止编译结果传入