### PR TITLE
JS_FreeValue中释放ptr使用free而不是delete

### DIFF
--- a/unity/Assets/core/upm/Editor/Resources/puerts/xil2cpp/pesapi_webgl.cpp.txt
+++ b/unity/Assets/core/upm/Editor/Resources/puerts/xil2cpp/pesapi_webgl.cpp.txt
@@ -157,11 +157,11 @@ inline void JS_FreeValue(JSValue v)
     {
         if (v.tag == JS_TAG_STRING || v.tag == JS_TAG_EXCEPTION || v.tag == JS_TAG_STRING16)
         {
-            delete v.u.str.ptr;
+            free(v.u.str.ptr);
         }
         if (v.tag == JS_TAG_BUFFER)
         {
-            delete (uint8_t *)v.u.buf.ptr;
+            free(v.u.buf.ptr);
         }
     }
     v.u.ptr = nullptr;


### PR DESCRIPTION
修复此问题：#2247