### PR TITLE
[Unreal]修改 Net 版本获取的方式为从引擎的 UnrealBuildTool 获取

### DIFF
--- a/unreal/Puerts/Source/CSharpParamDefaultValueMetas/DotNetTarget.csproj.props
+++ b/unreal/Puerts/Source/CSharpParamDefaultValueMetas/DotNetTarget.csproj.props
@@ -2,9 +2,19 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <DotNet8Path>$([System.IO.Directory]::GetDirectories('$(EngineDir)\Binaries\ThirdParty\DotNet', '8.0.*'))</DotNet8Path>
-    <TargetFramework Condition="'$(DotNet8Path)' != ''">net8.0</TargetFramework>
-    <TargetFramework Condition="'$(DotNet8Path)' == ''">net6.0</TargetFramework>
+    <!-- 读取引擎的配置 -->
+    <UbtPath>$(EngineDir)\Source\Programs\UnrealBuildTool\UnrealBuildTool.csproj</UbtPath>
+    <UbtContent Condition="Exists('$(UbtPath)')">$([System.IO.File]::ReadAllText('$(UbtPath)'))</UbtContent>
+
+    <!-- 正则提取 -->
+    <!-- 原文逻辑: <TargetFramework>net6.0</TargetFramework> -->
+    <!-- 转义后: &lt;TargetFramework&gt;(.*?)&lt;/TargetFramework&gt; -->
+    <!-- Groups[1].Value 取的是括号里匹配到的内容 -->
+    <UbtFrameworkRaw>$([System.Text.RegularExpressions.Regex]::Match('$(UbtContent)', '&lt;TargetFramework&gt;\s*(.+?)\s*&lt;/TargetFramework&gt;').Groups[1].Value)</UbtFrameworkRaw>
+
+    <!-- 设置版本 (如果没读到，默认兜底 net8.0) -->
+    <TargetFramework Condition="'$(UbtFrameworkRaw)' != ''">$(UbtFrameworkRaw)</TargetFramework>
+    <TargetFramework Condition="'$(UbtFrameworkRaw)' == ''">net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
原本的获取方式对于源码版引擎可能会有获取错误的情况
<img width="781" height="344" alt="image" src="https://github.com/user-attachments/assets/c06959e4-ff8b-4adc-b828-258568148152" />
有可能本地同时存在两种 Net 版本，故改用从 `\Engine\Source\Programs\UnrealBuildTool\UnrealBuildTool.csproj` 文件中获取实际引擎应该使用的版本
<img width="920" height="286" alt="image" src="https://github.com/user-attachments/assets/fd22126b-4392-4349-b561-994dd506162a" />
