### PR TITLE
给std::function的静态绑定增加引用类型参数的支持，以解决使用引用类型参数时会发生多次意外复制，以及无法传回数据的修改的问题

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Public/ScriptBackend.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/ScriptBackend.hpp
@@ -117,12 +117,16 @@
 #define __DefObjectType_HELPER2(CLS, Suffix) __DefObjectType_HELPER1(CLS, Suffix)
 #define __DefCDataPointerConverter_HELPER1(CLS, Suffix) __DefCDataPointerConverter_##Suffix(CLS)
 #define __DefCDataPointerConverter_HELPER2(CLS, Suffix) __DefCDataPointerConverter_HELPER1(CLS, Suffix)
+#define __DefCDataRefConverter_HELPER1(CLS, Suffix) __DefCDataRefConverter_##Suffix(CLS)
+#define __DefCDataRefConverter_HELPER2(CLS, Suffix) __DefCDataRefConverter_HELPER1(CLS, Suffix)
 #define __DefObjectType(CLS) __DefObjectType_HELPER2(CLS, PUERTS_BINDING_IMPL)
 #define __DefCDataPointerConverter(CLS) __DefCDataPointerConverter_HELPER2(CLS, PUERTS_BINDING_IMPL)
+#define __DefCDataRefConverter(CLS) __DefCDataRefConverter_HELPER2(CLS, PUERTS_BINDING_IMPL)
 #define __DefCDataConverter_HELPER1(CLS, Suffix) __DefCDataConverter_##Suffix(CLS)
 #define __DefCDataConverter_HELPER2(CLS, Suffix) __DefCDataConverter_HELPER1(CLS, Suffix)
 #define __DefCDataConverter(CLS) __DefCDataConverter_HELPER2(CLS, PUERTS_BINDING_IMPL)
-#define UsingNamedCppType(CLS, NAME) __DefScriptTTypeName(NAME, CLS) __DefObjectType(CLS) __DefCDataPointerConverter(CLS)
+#define UsingNamedCppType(CLS, NAME) \
+    __DefScriptTTypeName(NAME, CLS) __DefObjectType(CLS) __DefCDataPointerConverter(CLS) __DefCDataRefConverter(CLS)
 
 #define UsingCppType(CLS) UsingNamedCppType(CLS, CLS)
 

--- a/unreal/Puerts/Source/JsEnv/Public/StaticCall.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/StaticCall.hpp
@@ -1349,7 +1349,8 @@ struct PropertyWrapper;
 
 template <typename API, class Ins, class Ret, Ret Ins::*member, typename IncPass>
 struct PropertyWrapper<API, Ret Ins::*, member, IncPass,
-    typename std::enable_if<!is_objecttype<Ret>::value && !is_uetype<Ret>::value && !IsBoundedArray<Ret>::value>::type>
+    typename std::enable_if<!is_objecttype<std::decay_t<Ret>>::value && !is_uetype<std::decay_t<Ret>>::value &&
+                            !IsBoundedArray<Ret>::value>::type>
 {
     template <typename T>
     using DecayTypeConverter = typename API::template Converter<typename internal::ConverterDecay<T>::type>;
@@ -1388,7 +1389,8 @@ struct PropertyWrapper<API, Ret Ins::*, member, IncPass,
 
 template <typename API, class Ins, class Ret, Ret Ins::*member, typename IncPass>
 struct PropertyWrapper<API, Ret Ins::*, member, IncPass,
-    typename std::enable_if<!is_objecttype<Ret>::value && !is_uetype<Ret>::value && IsBoundedArray<Ret>::value>::type>
+    typename std::enable_if<!is_objecttype<std::decay_t<Ret>>::value && !is_uetype<std::decay_t<Ret>>::value &&
+                            IsBoundedArray<Ret>::value>::type>
 {
     template <typename T>
     using DecayTypeConverter = typename API::template Converter<typename internal::ConverterDecay<T>::type>;
@@ -1439,7 +1441,7 @@ struct PropertyWrapper<API, Ret Ins::*, member, IncPass,
 
 template <typename API, class Ins, class Ret, Ret Ins::*member, typename IncPass>
 struct PropertyWrapper<API, Ret Ins::*, member, IncPass,
-    typename std::enable_if<is_objecttype<Ret>::value || is_uetype<Ret>::value>::type>
+    typename std::enable_if<is_objecttype<std::decay_t<Ret>>::value || is_uetype<std::decay_t<Ret>>::value>::type>
 {
     template <typename T>
     using DecayTypeConverter = typename API::template Converter<typename internal::ConverterDecay<T>::type>;

--- a/unreal/Puerts/Source/JsEnv/Public/StdFunctionConverter.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/StdFunctionConverter.hpp
@@ -19,7 +19,7 @@ struct Converter<std::function<R(Args...)>>
         if (API::IsNullOrUndefined(context, value))
             return nullptr;
         Function _Func(context, value);
-        return [=](Args... cppArgs) -> R { return _Func.Func<R>(cppArgs...); };
+        return [=](Args&&... cppArgs) -> R { return _Func.Func<R>(std::forward<Args>(cppArgs)...); };
     }
 
     static bool accept(API::ContextType context, const API::ValueType value)
@@ -41,7 +41,7 @@ struct Converter<std::function<void(Args...)>>
         if (API::IsNullOrUndefined(context, value))
             return nullptr;
         Function PF(context, value);
-        return [=](Args... cppArgs) -> void { PF.Action(cppArgs...); };
+        return [=](Args&&... cppArgs) -> void { PF.Action(std::forward<Args>(cppArgs)...); };
     }
 
     static bool accept(API::ContextType context, const API::ValueType value)

--- a/unreal/Puerts/Source/JsEnv/Public/TypeInfo.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/TypeInfo.hpp
@@ -274,7 +274,7 @@ struct ScriptTypeName<T&,
 {
     static constexpr auto value()
     {
-        return internal::Literal("$Ref<") + ScriptTypeName<std::decay<T>::type>::value() + internal::Literal(">");
+        return internal::Literal("$Ref<") + ScriptTypeName<typename std::decay<T>::type>::value() + internal::Literal(">");
     }
 };
 

--- a/unreal/Puerts/Source/JsEnv/Public/UEDataBinding.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/UEDataBinding.hpp
@@ -99,7 +99,7 @@
 
 #define UsingUStruct(CLS) UsingUClass(CLS)
 
-#define UsingContainer(CLS) __DefObjectType(CLS) __DefCDataPointerConverter(CLS)
+#define UsingContainer(CLS) __DefObjectType(CLS) __DefCDataPointerConverter(CLS) __DefCDataRefConverter(CLS)
 
 #define UsingTSharedPtr(ITEMCLS) __DefObjectType(TSharedPtr<ITEMCLS>) __DefCDataPointerConverter(TSharedPtr<ITEMCLS>)
 

--- a/unreal/Puerts/Source/JsEnv/Public/V8Object.hpp
+++ b/unreal/Puerts/Source/JsEnv/Public/V8Object.hpp
@@ -328,7 +328,8 @@ private:
     void applyWriteBack(
         v8::Local<v8::Context>& context, Tuple&& argsTuple, v8::Local<v8::Value>* Argv, std::index_sequence<I...>) const
     {
-        (applyWriteBackOne<I, OriginalTuple>(context, argsTuple, Argv), ...);
+        using expander = int[];
+        (void) expander{0, (applyWriteBackOne<I, OriginalTuple>(context, argsTuple, Argv), 0)...};
     }
 
     template <typename... Args>


### PR DESCRIPTION
给std::function的静态绑定增加引用类型参数的支持，以解决使用引用类型参数时会发生多次意外复制，以及无法传回数据的修改的问题，同时给一些模板的类型匹配加上std::decay_t，避免某些时候出现匹配错误