### PR TITLE
fix: nodejs builtin import support

### DIFF
--- a/unity/test/Src/Cases/Javascript/API/NodeJSTest.cs
+++ b/unity/test/Src/Cases/Javascript/API/NodeJSTest.cs
@@ -17,5 +17,42 @@ namespace Puerts.UnitTest
                 Assert.AreEqual(pid, System.Diagnostics.Process.GetCurrentProcess().Id);
             }
         }
+
+        [Test]
+        public void ImportNodeBuiltinsAsESM()
+        {
+            var env = UnitTestEnv.GetEnv();
+            var loader = UnitTestEnv.GetLoader();
+
+            loader.AddMockFileContent("node-builtin-import/main.mjs", @"
+                import * as fs from ""fs"";
+                import * as fs2 from ""node:fs"";
+                import { createRequire } from ""node:module"";
+                import { Buffer } from ""node:buffer"";
+
+                const requiredFs = require(""fs"");
+
+                export const ok =
+                    typeof fs.writeFileSync === ""function"" &&
+                    fs.writeFileSync === fs2.writeFileSync &&
+                    typeof createRequire === ""function"" &&
+                    Buffer.from(""ok"").toString() === ""ok"" &&
+                    typeof requiredFs.writeFileSync === ""function"";
+
+                export const sameRequire = requiredFs.writeFileSync === fs.writeFileSync;
+            ");
+
+            if (env.Backend.GetType().Name == "BackendNodeJS")
+            {
+                var exports = env.ExecuteModule("node-builtin-import/main.mjs");
+
+                Assert.True(exports.Get<bool>("ok"));
+                Assert.True(exports.Get<bool>("sameRequire"));
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => env.ExecuteModule("node-builtin-import/main.mjs"));
+            }
+        }
     }
 }

--- a/unity/upms/core/Runtime/Resources/puerts/esm_bootstrap.cjs
+++ b/unity/upms/core/Runtime/Resources/puerts/esm_bootstrap.cjs
@@ -180,8 +180,74 @@
         return __loader;
     }
 
+    const isValidExportName = (name) => /^[A-Za-z_$][0-9A-Za-z_$]*$/.test(name)
+
+    const jsonString = (value) => JSON.stringify(value)
+
+    let __node_builtin_modules = undefined
+    const getNodeBuiltinModules = () => {
+        if (!global.process || !global.process.versions || !global.process.versions.node || typeof global.require !== 'function') {
+            return undefined
+        }
+        if (!__node_builtin_modules) {
+            let builtinModules
+            try {
+                const nodeModule = global.require('module')
+                builtinModules = nodeModule && nodeModule.builtinModules
+            } catch {
+                return undefined
+            }
+            if (!builtinModules || typeof builtinModules[Symbol.iterator] !== 'function') {
+                return undefined
+            }
+            __node_builtin_modules = new Set()
+            for (const name of builtinModules) {
+                if (typeof name !== 'string') continue
+                __node_builtin_modules.add(name)
+                __node_builtin_modules.add(name.startsWith('node:') ? name.slice(5) : `node:${name}`)
+            }
+        }
+        return __node_builtin_modules
+    }
+
+    const resolveNodeBuiltinSpecifier = (specifier) => {
+        const builtins = getNodeBuiltinModules()
+        if (!builtins || typeof specifier !== 'string') return undefined
+
+        if (specifier.startsWith('node:')) {
+            const name = specifier.slice(5)
+            return builtins.has(name) || builtins.has(specifier) ? `node:${name}` : undefined
+        }
+
+        return builtins.has(specifier) || builtins.has(`node:${specifier}`) ? `node:${specifier}` : undefined
+    }
+
+    const createNodeBuiltinESMWrapper = (specifier) => {
+        const mod = global.require(specifier)
+        const lines = [
+            `const __puer_builtin = globalThis.require(${jsonString(specifier)});`,
+            'export default __puer_builtin;'
+        ]
+        let index = 0
+        for (const key of Reflect.ownKeys(mod)) {
+            if (typeof key !== 'string') continue
+            if (key === 'default' || key === '__esModule') continue
+            if (!isValidExportName(key)) continue
+
+            const localName = `__puer_builtin_export_${index++}`
+            lines.push(`const ${localName} = __puer_builtin[${jsonString(key)}];`)
+            lines.push(`export { ${localName} as ${key} };`)
+        }
+        return lines.join('\n')
+    }
+
     global.__puer_resolve_module_url__ = function(specifier, referer) {
         const originSp = specifier;
+        const nodeBuiltinSpecifier = resolveNodeBuiltinSpecifier(specifier)
+        if (nodeBuiltinSpecifier) {
+            return nodeBuiltinSpecifier
+        }
+
         const loader = getLoader();
         if (!loader.Resolve) {
             let s = !__puer_path__.isRelative(specifier) ? specifier :
@@ -203,6 +269,11 @@
 
     global.__puer_resolve_module_content__ = function(specifier, debugpathRef = []) {
         const originSp = specifier;
+        const nodeBuiltinSpecifier = resolveNodeBuiltinSpecifier(specifier)
+        if (nodeBuiltinSpecifier) {
+            return createNodeBuiltinESMWrapper(nodeBuiltinSpecifier)
+        }
+
         const loader = getLoader();
         let isESM = true;
         if (loader.IsESM) isESM = specifier.startsWith('puerts/') || loader.IsESM(specifier)


### PR DESCRIPTION
related to #1836 .
现在 puerts 的 nodejs 版本对 nodejs 内置模块如 fs, buffer 等解析被删去了，因为 puerts 这里开 v8 的时候用了 `kNoRegisterESMLoader`，本质上这是为了让框架层注册的 `ILoader` 来处理模块解析和依赖，但是这也让内置模块的依赖没法使用。


目前版本这种情况下，写 `import { Buffer } from 'node:buffer'` 会导致使用注册的 `ILoader` 来解析 `node:buffer`模块，自然没法找到，因此会如 #1836 报找不到模块。新增了一个 `ImportNodeBuiltinsAsESM` 测试，用 nuget 来的 3.0.2 可以复现问题；使用修复版本可以验证解决问题。这个问题在 3.0.2 及以前的 2.2.3 都是存在的。


大体是在 [esm_bootstrap.cjs](https://github.com/Tencent/puerts/compare/master...wintbiit:puerts:fix/nodejs-import-builtin?expand=1#diff-4ce1ab599a3eb9a54dedc7fb41bd30840e66d0d0cac4db8a67eb27c5471d845b)纯js层做修复，不动原生层，在 node环境下复用require 去拿 builtin module列表，然后为 builtin 生成一个 ESM wrapper，wrapper 内部用 `require`