### PR TITLE
[unreal]处理升级UE5.5和5.7版本版本带来的警告

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/ContainerMeta.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/ContainerMeta.cpp
@@ -210,7 +210,11 @@ PropertyMacro* FContainerMeta::GetObjectProperty(UField* Field)
 #elif ENGINE_MINOR_VERSION > 0 && ENGINE_MAJOR_VERSION > 4
         Ret = new FStructProperty(PropertyMetaRoot, NAME_None, RF_Transient);
         static_cast<FStructProperty*>(Ret)->Struct = ScriptStruct;
+#if ENGINE_MINOR_VERSION >= 5 && ENGINE_MAJOR_VERSION >= 5
+        Ret->SetElementSize(ScriptStruct->PropertiesSize);
+#else
         Ret->ElementSize = ScriptStruct->PropertiesSize;
+#endif
         Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
 #else
         Ret = new FStructProperty(PropertyMetaRoot, NAME_None, RF_Transient, 0, CPF_HasGetValueTypeHash, ScriptStruct);
@@ -236,7 +240,11 @@ PropertyMacro* FContainerMeta::GetObjectProperty(UField* Field)
 #endif
             FNumericProperty* UnderlyingProp = new FByteProperty(EnumProp, TEXT("UnderlyingType"), RF_Transient);
             EnumProp->AddCppProperty(UnderlyingProp);
+#if ENGINE_MINOR_VERSION >= 5 && ENGINE_MAJOR_VERSION >= 5
+            EnumProp->SetElementSize(UnderlyingProp->GetElementSize());
+#else
             EnumProp->ElementSize = UnderlyingProp->ElementSize;
+#endif
             EnumProp->PropertyFlags |= CPF_IsPlainOldData | CPF_NoDestructor | CPF_ZeroConstructor;
 
             Ret = EnumProp;

--- a/unreal/Puerts/Source/JsEnv/Private/ContainerWrapper.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/ContainerWrapper.cpp
@@ -795,7 +795,11 @@ void FFixSizeArrayWrapper::InternalGet(const v8::FunctionCallbackInfo<v8::Value>
         return;
     }
 
+#if ENGINE_MINOR_VERSION >= 5 && ENGINE_MAJOR_VERSION >= 5
+    auto Ptr = Self + Property->GetElementSize() * Index;
+#else
     auto Ptr = Self + Property->ElementSize * Index;
+#endif
 
     auto Ret = Inner->UEToJs(Isolate, Context, Ptr, PassByPointer);
     if (Inner->NeedLinkOuter && PassByPointer)
@@ -843,7 +847,11 @@ void FFixSizeArrayWrapper::Set(const v8::FunctionCallbackInfo<v8::Value>& Info)
         return;
     }
 
+#if ENGINE_MINOR_VERSION >= 5 && ENGINE_MAJOR_VERSION >= 5
+    auto Ptr = Self + Property->GetElementSize() * Index;
+#else
     auto Ptr = Self + Property->ElementSize * Index;
+#endif
 
     Inner->JsToUE(Isolate, Context, Info[1], Ptr, true);
 }

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -2176,7 +2176,11 @@ static void SkipFunction(FFrame& Stack, RESULT_DECL, UFunction* Function)
     if (ReturnProp != NULL)
     {
         ReturnProp->DestroyValue(RESULT_PARAM);
+#if ENGINE_MINOR_VERSION >= 5 && ENGINE_MAJOR_VERSION >= 5
+        FMemory::Memzero(RESULT_PARAM, ReturnProp->ArrayDim * ReturnProp->GetElementSize());
+#else
         FMemory::Memzero(RESULT_PARAM, ReturnProp->ArrayDim * ReturnProp->ElementSize);
+#endif
     }
 }
 

--- a/unreal/Puerts/Source/JsEnv/Private/StructWrapper.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/StructWrapper.cpp
@@ -505,7 +505,11 @@ void FStructWrapper::Find(const v8::FunctionCallbackInfo<v8::Value>& Info)
         if (Info.Length() > 1)
         {
             UObject* Outer = FV8Utils::GetUObject(Context, Info[1]);
+#if ENGINE_MINOR_VERSION >= 7 && ENGINE_MAJOR_VERSION >= 5
+            Object = StaticFindObject(Class, Outer, *FV8Utils::ToFString(Isolate, Info[0]), EFindObjectFlags::None);
+#else
             Object = StaticFindObject(Class, Outer, *FV8Utils::ToFString(Isolate, Info[0]), false);
+#endif
         }
         else
         {


### PR DESCRIPTION
1. StaticFindObject：UE5.7版本正式更新了接口，将 bool 替换为了 EFindObjectFlags，此次提交主要是处理编译期的警告

https://github.com/EpicGames/UnrealEngine/blob/260bb2e1c5610b31c63a36206eedd289409c5f11/Engine/Source/Runtime/CoreUObject/Public/UObject/UObjectGlobals.h#L356

```

/**
 * Tries to find an object in memory. This will handle fully qualified paths of the form /path/packagename.object:subobject and resolve references for you.
 *
 * @param	Class			The to be found object's class
 * @param	InOuter			Outer object to look inside. If this is null then InName should start with a package name
 * @param	InName			The object path to search for an object, relative to InOuter
 * @param	Flags			Flags which control the search
 *
 * @return	Returns a pointer to the found object or nullptr if none could be found
 */
COREUOBJECT_API UObject* StaticFindObject( UClass* Class, UObject* InOuter, FStringView Name, EFindObjectFlags Flags = EFindObjectFlags::None );
template <UE::CSameAs<bool> ExactClassType>
UE_EXACTCLASS_BOOL_DEPRECATED("StaticFindObject")
UE_NODEBUG UE_FORCEINLINE_HINT UObject* StaticFindObject( UClass* Class, UObject* InOuter, FStringView Name, ExactClassType bExactClass )
{
	return StaticFindObject(Class, InOuter, Name, bExactClass ? EFindObjectFlags::ExactClass : EFindObjectFlags::None);
}

```



2. ElementSize：UE5.5版本之后统一使用Get/Set方法，此次提交主要是处理编译期的警告

https://github.com/EpicGames/UnrealEngine/blob/2d53fcab0066b1f16dd956b227720841cad0f6f7/Engine/Source/Runtime/CoreUObject/Public/UObject/UnrealType.h#L194

```

class FProperty : public FField
{
	DECLARE_FIELD_API(FProperty, FField, CASTCLASS_FProperty, UE_API)

	// Persistent variables.
	int32			ArrayDim;
	UE_DEPRECATED(5.5, "Use GetElementSize/SetElementSize instead.")
	int32			ElementSize;
public:
	EPropertyFlags	PropertyFlags;
	uint16			RepIndex;
	
	
	
	// ElementSize accessors to facilitate underlying type change
	COREUOBJECT_API void SetElementSize(int32 NewSize);
	int32 	GetElementSize() const
	{
PRAGMA_DISABLE_DEPRECATION_WARNINGS
		return ElementSize;
PRAGMA_ENABLE_DEPRECATION_WARNINGS
	}
	
	```