### PR TITLE
RedirectToTypeScriptFinish 设置 FUNC_Native 后补充 Function->Bind()

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/TypeScriptGeneratedClass.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/TypeScriptGeneratedClass.cpp
@@ -239,6 +239,7 @@ void UTypeScriptGeneratedClass::RedirectToTypeScriptFinish()
             continue;
         }
         Function->FunctionFlags |= FUNC_BlueprintCallable | FUNC_BlueprintEvent | FUNC_Public | FUNC_Native;
+        Function->Bind();
     }
 }
 


### PR DESCRIPTION
# 中文 Issue / Draft PR 草稿：RedirectToTypeScriptFinish 设置 FUNC_Native 后补充 Bind

## 标题

`UTypeScriptGeneratedClass::RedirectToTypeScriptFinish()` 设置 `FUNC_Native` 后需要调用 `Function->Bind()`

## 摘要

在 UE 5.7 的最小复现工程里，`UTypeScriptGeneratedClass::RedirectToTypeScriptFinish()` 会把被重定向的 Blueprint 函数标记为 `FUNC_Native`，但没有在修改 flag 后调用 `UFunction::Bind()`。

结果是：UE 的 lifecycle / `ProcessEvent` 能触发到对应 `UFunction`，但 native dispatch 入口没有重新绑定到 PuerTS 的 JS thunk，最终不会进入 TS/JS 侧函数。

在同一份最小复现里，补充：

```cpp
Function->FunctionFlags |= FUNC_BlueprintCallable | FUNC_BlueprintEvent | FUNC_Public | FUNC_Native;
Function->Bind();
```

后，`ReceiveBeginPlay`、`ReceiveTick`、普通实例函数 `Probe` / `CustomVoid` / `ProbeCallsLocal` 都可以正常进入 TS/JS。

## 当前补丁

分支：

```text
fix/redirected-ufunction-bind
```

commit：

```text
0880d1d2fbb7e1aafade515a4be881e36ee7fb4a Bind redirected TypeScript functions
```

修改文件：

```text
unreal/Puerts/Source/JsEnv/Private/TypeScriptGeneratedClass.cpp
```

补丁范围只有一行 `Function->Bind()`，没有包含诊断日志、测试工程或 hot reload 临时代码。

## 复现环境

- PuerTS upstream master commit: `a9a5564ed295897cba1e8a57f5021905df72233f`
- UE: `5.7.4`
- 平台：Windows
- 最小测试工程：外部隔离工程 `PuertsBindRepro`
- TS 类：`TickProbe extends UE.Actor`
- 调用方式：
  - UE lifecycle: `ReceiveBeginPlay` / `ReceiveTick`
  - C++ `ProcessEvent`: `Probe` / `CustomVoid` / `ProbeCallsLocal`

## 失败现象

无 `Function->Bind()` 时：

- `TickProbe_C` actor 可以创建。
- C++ 每秒能输出 `ProcessEvent Probe` / `ProcessEvent CustomVoid` / `ProcessEvent ProbeCallsLocal`。
- 但没有对应的 `[TickProbe] Probe ...` / `[TickProbe] CustomVoid ...` / `[TickProbe] ProbeCallsLocal ...`。
- lifecycle 侧也没有进入 `[TickProbe] BeginPlay ...` / `[TickProbe] Tick ...`。

关键日志：

```text
Failed to bind native function REINST_TickProbe_C_0.ReceiveTick
Failed to bind native function REINST_TickProbe_C_0.ReceiveBeginPlay
Failed to bind native function REINST_TickProbe_C_0.Probe
Failed to bind native function REINST_TickProbe_C_0.CustomVoid
Failed to bind native function REINST_TickProbe_C_0.ProbeCallsLocal
```

注意：`REINST_... Failed to bind native function` 在加补丁后仍可能出现，所以它不能单独作为最终失败判据。真正判据是最终 actor 的 lifecycle / `ProcessEvent` 后是否进入 TS/JS 日志。

## 通过现象

加 `Function->Bind()` 后，最终 actor `TickProbe_C` 输出：

```text
[TickProbe] BeginPlay probe-v2
[TickProbe] Tick probe-v2
[TickProbe] Probe probe-v2
[TickProbe] CustomVoid probe-v2
[TickProbe] ProbeCallsLocal local-probe-v2
```

Phase 7 使用 clean branch patch 复测日志：

```text
D:\ClaudeTasks\active\puerts-bind-ab-repro\test\phase7-clean-branch-bind-function-matrix.log
```

## 影响范围说明

这不是声明“所有 PuerTS 函数路径都有问题”。

当前已经验证的范围是：

- 经过 `FunctionToRedirect`。
- 由 `RedirectToTypeScriptFinish()` 收尾。
- 之后通过 UE lifecycle 或 `ProcessEvent` 调度的 redirected `UFunction`。

当前没有验证的范围：

- BlueprintFunctionLibrary / static path。
- 非 UObject TS module 直接 JS 调用。
- lazy-load-only path。

源码上，本补丁只在 `RedirectToTypeScriptFinish()` 内、`FunctionToRedirect.Contains(...)` 命中的函数上调用 `Bind()`。不走该 finish 路径的函数不会执行新增代码。

运行对照上，无 Bind 时 `[TickProbe] Constructor probe-v2` 已经能输出，但 lifecycle / `ProcessEvent` 函数不进入 JS，说明问题集中在 redirected `UFunction` native dispatch，而不是 JS 环境整体不可用。

## 和 PR #2339 的关系

PR #2339 解决的是另一个相关但不同的问题：引入新的 import 后，TS 代码热编译时，继承自 UObject 的 TS 类没有完成强制 reinject / prototype 链刷新，导致现有对象仍使用旧逻辑。

本补丁不替代 PR #2339，也不解决新增 import 的 module cache / hot reload 问题。

更准确的关系是：

- PR #2339：修 hot reload 后 `UTypeScriptGeneratedClass` / prototype 链刷新问题。
- 本补丁：修 `RedirectToTypeScriptFinish()` 设置 `FUNC_Native` 后，UE native dispatch 入口没有重新 `Bind()` 的问题。

两个问题在热重载 / 重新生成 BP 场景下可能一起暴露，但修复点不同。

## 建议提交方式

当前建议先开 Issue 或 Draft PR，不建议直接开正式 PR。

原因：

- 复现工程还在仓库外，不是 upstream 自动化测试。
- 当前只覆盖 UE 5.7.4 + Actor generated class + redirected UFunction。
- BlueprintFunctionLibrary / static / lazy-load-only 尚未运行覆盖。
- 需要维护者确认这个 `Bind()` 调用是否符合他们对所有支持 UE 版本的预期。

如果开 Draft PR，建议标题限定为：

```text
Bind redirected TypeScript UFunctions after setting FUNC_Native
```

正文避免写“修复所有 PuerTS 函数不生效”，而写：

```text
修复 RedirectToTypeScriptFinish() 设置 FUNC_Native 后，已测 redirected UFunction 在 UE lifecycle / ProcessEvent 调度时不进入 JS 的问题。
```
