### PR TITLE
feat: add TWeakObjectPtr support in TypeScript via UE.MakeWeakObjectPtr

### DIFF
--- a/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
+++ b/unreal/Puerts/Content/JavaScript/puerts/uelazyload.js
@@ -200,6 +200,9 @@ var global = global || (function () { return this; }());
     rawSet(UE, 'NewStruct', global.__tgjsNewStruct);
     global.__tgjsNewStruct = undefined;
     
+    rawSet(UE, 'MakeWeakObjectPtr', global.__tgjsMakeWeakObjectPtr);
+    global.__tgjsMakeWeakObjectPtr = undefined;
+    
     puerts.$ref = ref;
     puerts.$unref = unref;
     puerts.$set = setref;

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -15,6 +15,7 @@
 #include "DelegateWrapper.h"
 #include "ContainerWrapper.h"
 #include "SoftObjectWrapper.h"
+#include "WeakObjectPtrWrapper.h"
 #include "V8Utils.h"
 #include "ObjectMapper.h"
 #include "JSLogger.h"
@@ -515,6 +516,8 @@ FJsEnvImpl::FJsEnvImpl(std::shared_ptr<IJSModuleLoader> InModuleLoader, std::sha
 
     MethodBindingHelper<&FJsEnvImpl::NewStructByScriptStruct>::Bind(Isolate, Context, Global, "__tgjsNewStruct", This);
 
+    MethodBindingHelper<&FJsEnvImpl::MakeWeakObjectPtr>::Bind(Isolate, Context, Global, "__tgjsMakeWeakObjectPtr", This);
+
 #if !defined(ENGINE_INDEPENDENT_JSENV)
     MethodBindingHelper<&FJsEnvImpl::MakeUClass>::Bind(Isolate, Context, Global, "__tgjsMakeUClass", This);
 
@@ -609,6 +612,9 @@ FJsEnvImpl::FJsEnvImpl(std::shared_ptr<IJSModuleLoader> InModuleLoader, std::sha
         v8::UniquePersistent<v8::FunctionTemplate>(Isolate, FMulticastDelegateWrapper::ToFunctionTemplate(Isolate));
 
     SoftObjectPtrTemplate = v8::UniquePersistent<v8::FunctionTemplate>(Isolate, FSoftObjectWrapper::ToFunctionTemplate(Isolate));
+
+    WeakObjectPtrTemplate =
+        v8::UniquePersistent<v8::FunctionTemplate>(Isolate, FWeakObjectPtrWrapper::ToFunctionTemplate(Isolate));
 
     DynamicInvoker = MakeShared<DynamicInvokerImpl, ESPMode::ThreadSafe>(this);
     MixinInvoker = DynamicInvoker;
@@ -870,6 +876,7 @@ FJsEnvImpl::~FJsEnvImpl()
         DynamicInvoker.Reset();
         MixinInvoker.Reset();
 
+        WeakObjectPtrTemplate.Reset();
         SoftObjectPtrTemplate.Reset();
         MulticastDelegateTemplate.Reset();
         DelegateTemplate.Reset();
@@ -1142,6 +1149,39 @@ void FJsEnvImpl::NewStructByScriptStruct(const v8::FunctionCallbackInfo<v8::Valu
     {
         FV8Utils::ThrowException(Isolate, "invalid argument");
     }
+}
+
+void FJsEnvImpl::MakeWeakObjectPtr(const v8::FunctionCallbackInfo<v8::Value>& Info)
+{
+    v8::Isolate* Isolate = Info.GetIsolate();
+    v8::Isolate::Scope IsolateScope(Isolate);
+    v8::HandleScope HandleScope(Isolate);
+    v8::Local<v8::Context> Context = Isolate->GetCurrentContext();
+    v8::Context::Scope ContextScope(Context);
+
+    UObject* Object = reinterpret_cast<UObject*>(FV8Utils::GetPointer(Context, Info[0]));
+    if (FV8Utils::IsReleasedPtr(Object))
+    {
+        Object = nullptr;
+    }
+
+    TWeakObjectPtr<UObject>* WeakPtr = new TWeakObjectPtr<UObject>(Object);
+
+    const auto JSObject = WeakObjectPtrTemplate.Get(Isolate)->InstanceTemplate()->NewInstance(Context).ToLocalChecked();
+    DataTransfer::SetPointer(Isolate, JSObject, WeakPtr, 0);
+
+    v8::Global<v8::Object>* GlobalPtr = new v8::Global<v8::Object>(Isolate, JSObject);
+    GlobalPtr->SetWeak<v8::Global<v8::Object>>(
+        GlobalPtr,
+        [](const v8::WeakCallbackInfo<v8::Global<v8::Object>>& Data)
+        {
+            void* Ptr = DataTransfer::MakeAddressWithHighPartOfTwo(Data.GetInternalField(0), Data.GetInternalField(1));
+            delete static_cast<TWeakObjectPtr<UObject>*>(Ptr);
+            delete Data.GetParameter();
+        },
+        v8::WeakCallbackType::kInternalFields);
+
+    Info.GetReturnValue().Set(JSObject);
 }
 
 bool FJsEnvImpl::IdleNotificationDeadline(double DeadlineInSeconds)

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.h
@@ -330,6 +330,8 @@ private:
 
     void NewStructByScriptStruct(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
+    void MakeWeakObjectPtr(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
 #if !defined(ENGINE_INDEPENDENT_JSENV)
     void MakeUClass(const v8::FunctionCallbackInfo<v8::Value>& Info);
 
@@ -693,6 +695,8 @@ private:
     v8::UniquePersistent<v8::FunctionTemplate> MulticastDelegateTemplate;
 
     v8::UniquePersistent<v8::FunctionTemplate> SoftObjectPtrTemplate;
+
+    v8::UniquePersistent<v8::FunctionTemplate> WeakObjectPtrTemplate;
 
     std::map<void*, DelegateObjectInfo> DelegateMap;
 

--- a/unreal/Puerts/Source/JsEnv/Private/WeakObjectPtrWrapper.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/WeakObjectPtrWrapper.cpp
@@ -1,0 +1,55 @@
+#include "WeakObjectPtrWrapper.h"
+#include "V8Utils.h"
+#include "ObjectMapper.h"
+
+namespace PUERTS_NAMESPACE
+{
+v8::Local<v8::FunctionTemplate> FWeakObjectPtrWrapper::ToFunctionTemplate(v8::Isolate* Isolate)
+{
+	auto Result = v8::FunctionTemplate::New(Isolate);
+	Result->InstanceTemplate()->SetInternalFieldCount(4);
+	Result->PrototypeTemplate()->Set(FV8Utils::ToV8String(Isolate, "Get"), v8::FunctionTemplate::New(Isolate, &Get));
+	Result->PrototypeTemplate()->Set(FV8Utils::ToV8String(Isolate, "IsValid"), v8::FunctionTemplate::New(Isolate, &IsValid));
+	return Result;
+}
+
+void FWeakObjectPtrWrapper::Get(const v8::FunctionCallbackInfo<v8::Value>& Info)
+{
+	auto Isolate = Info.GetIsolate();
+	auto Context = Isolate->GetCurrentContext();
+
+	TWeakObjectPtr<UObject>* Ptr = FV8Utils::GetPointerFast<TWeakObjectPtr<UObject>>(Info.Holder());
+	if (!Ptr)
+	{
+		FV8Utils::ThrowException(Isolate, "invalid weak object ptr wrapper");
+		return;
+	}
+
+	UObject* Obj = Ptr->Get();
+	if (Obj && Obj->IsValidLowLevelFast() && !UEObjectIsPendingKill(Obj))
+	{
+		Info.GetReturnValue().Set(
+			FV8Utils::IsolateData<IObjectMapper>(Isolate)->FindOrAdd(Isolate, Context, Obj->GetClass(), Obj));
+	}
+	else
+	{
+		Info.GetReturnValue().Set(v8::Undefined(Isolate));
+	}
+}
+
+void FWeakObjectPtrWrapper::IsValid(const v8::FunctionCallbackInfo<v8::Value>& Info)
+{
+	auto Isolate = Info.GetIsolate();
+
+	TWeakObjectPtr<UObject>* Ptr = FV8Utils::GetPointerFast<TWeakObjectPtr<UObject>>(Info.Holder());
+	if (!Ptr)
+	{
+		Info.GetReturnValue().Set(v8::Boolean::New(Isolate, false));
+		return;
+	}
+
+	UObject* Obj = Ptr->Get();
+	bool bValid = Obj && Obj->IsValidLowLevelFast() && !UEObjectIsPendingKill(Obj);
+	Info.GetReturnValue().Set(v8::Boolean::New(Isolate, bValid));
+}
+}    // namespace PUERTS_NAMESPACE

--- a/unreal/Puerts/Source/JsEnv/Private/WeakObjectPtrWrapper.h
+++ b/unreal/Puerts/Source/JsEnv/Private/WeakObjectPtrWrapper.h
@@ -1,0 +1,34 @@
+/*
+ * Tencent is pleased to support the open source community by making Puerts available.
+ * Copyright (C) 2020 Tencent.  All rights reserved.
+ * Puerts is licensed under the BSD 3-Clause License, except for the third-party components listed in the file 'LICENSE' which may
+ * be subject to their corresponding license terms. This file is subject to the terms and conditions defined in file 'LICENSE',
+ * which is part of this source code package.
+ */
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "NamespaceDef.h"
+
+PRAGMA_DISABLE_UNDEFINED_IDENTIFIER_WARNINGS
+#pragma warning(push, 0)
+#include "libplatform/libplatform.h"
+#include "v8.h"
+#pragma warning(pop)
+PRAGMA_ENABLE_UNDEFINED_IDENTIFIER_WARNINGS
+
+namespace PUERTS_NAMESPACE
+{
+class FWeakObjectPtrWrapper
+{
+public:
+	static v8::Local<v8::FunctionTemplate> ToFunctionTemplate(v8::Isolate* Isolate);
+
+private:
+	static void Get(const v8::FunctionCallbackInfo<v8::Value>& Info);
+
+	static void IsValid(const v8::FunctionCallbackInfo<v8::Value>& Info);
+};
+}    // namespace PUERTS_NAMESPACE

--- a/unreal/Puerts/Typing/ue/puerts.d.ts
+++ b/unreal/Puerts/Typing/ue/puerts.d.ts
@@ -130,6 +130,13 @@ declare module "ue" {
     function NewStruct(St: ScriptStruct): object;
 
     function FNameLiteral(str:string):string;
+
+    interface WeakObjectPtr<T> {
+        Get(): T | undefined;
+        IsValid(): boolean;
+    }
+
+    function MakeWeakObjectPtr<T extends Object>(obj: T): WeakObjectPtr<T>;
     
     type TWeakObjectPtr<T> = {
         [K in keyof T]: T[K];


### PR DESCRIPTION
- Add FWeakObjectPtrWrapper class (WeakObjectPtrWrapper.h/.cpp) exposing Get()/IsValid() methods
- Integrate into FJsEnvImpl: WeakObjectPtrTemplate, MakeWeakObjectPtr binding
- Register UE.MakeWeakObjectPtr in uelazyload.js bootstrap
- Add WeakObjectPtr<T> interface and MakeWeakObjectPtr function to puerts.d.ts type declarations
- Null/PendingKill/invalid arguments return an inert WeakObjectPtr (IsValid=false, Get=undefined)