### PR TITLE
Fix UE5.8 compile error

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -2434,15 +2434,15 @@ void FJsEnvImpl::ExecuteDelegate(
     }
     else
     {
+        JsCallbackPrototypeMap[SignatureFunction]->Call(Isolate, Context, Info,
+            [MulticastScriptDelegate = static_cast<FMulticastScriptDelegate*>(DelegatePtr)](void* Params)
+            {
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
-        JsCallbackPrototypeMap[SignatureFunction]->Call(Isolate, Context, Info,
-            [MulticastScriptDelegate = static_cast<FMulticastScriptDelegate*>(DelegatePtr)](void* Params)
-            { MulticastScriptDelegate->ProcessDelegate<UObject>(Params); });
+                MulticastScriptDelegate->ProcessDelegate<UObject>(Params);
 #else
-        JsCallbackPrototypeMap[SignatureFunction]->Call(Isolate, Context, Info,
-            [MulticastScriptDelegate = static_cast<FMulticastScriptDelegate*>(DelegatePtr)](void* Params)
-            { MulticastScriptDelegate->ProcessMulticastDelegate<UObject>(Params); });
+                MulticastScriptDelegate->ProcessMulticastDelegate<UObject>(Params);
 #endif
+            });    
     }
 }
 

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -2442,7 +2442,7 @@ void FJsEnvImpl::ExecuteDelegate(
 #else
                 MulticastScriptDelegate->ProcessMulticastDelegate<UObject>(Params);
 #endif
-            });    
+            });
     }
 }
 

--- a/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JsEnvImpl.cpp
@@ -2434,9 +2434,15 @@ void FJsEnvImpl::ExecuteDelegate(
     }
     else
     {
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 8
+        JsCallbackPrototypeMap[SignatureFunction]->Call(Isolate, Context, Info,
+            [MulticastScriptDelegate = static_cast<FMulticastScriptDelegate*>(DelegatePtr)](void* Params)
+            { MulticastScriptDelegate->ProcessDelegate<UObject>(Params); });
+#else
         JsCallbackPrototypeMap[SignatureFunction]->Call(Isolate, Context, Info,
             [MulticastScriptDelegate = static_cast<FMulticastScriptDelegate*>(DelegatePtr)](void* Params)
             { MulticastScriptDelegate->ProcessMulticastDelegate<UObject>(Params); });
+#endif
     }
 }
 


### PR DESCRIPTION
Fix UE5.8 compile error because of the deprecate of TMulticastScriptDelegate::ProcessMulticastDelegate