### PR TITLE
fix(unreal): 修正 PIE 退出时序与 LatentInfo 默认参数生成

### DIFF
--- a/unreal/Puerts/Source/CSharpParamDefaultValueMetas/CSharpParamDefaultValueMetas.cs
+++ b/unreal/Puerts/Source/CSharpParamDefaultValueMetas/CSharpParamDefaultValueMetas.cs
@@ -109,6 +109,12 @@ namespace CSharpParamDefaultValueMetas
             }
         }
         
+        private static bool IsLatentInfoParameter(UhtFunction function, UhtProperty property)
+        {
+            return function.MetaData.TryGetValue("LatentInfo", out string? latentInfoParameterName)
+                && string.Equals(latentInfoParameterName, property.SourceName, StringComparison.Ordinal);
+        }
+
         private static bool TryGetDefaultValue(UhtMetaData metaData, UhtProperty property, out string value)
         {
             var hasValue = metaData.TryGetValue(property.SourceName, out string? tempValue);
@@ -132,8 +138,14 @@ namespace CSharpParamDefaultValueMetas
             
             foreach (var property in properties.OrderBy(Property => Property.SourceName))
             {
+                if (IsLatentInfoParameter(uhtFunction, property))
+                {
+                    continue;
+                }
+
                 if (TryGetDefaultValue(uhtFunction.MetaData, property, out string defaultValue))
                 {
+
                     declareClassOnce();
                     if (!declared)
                     {

--- a/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/FunctionTranslator.cpp
@@ -155,6 +155,12 @@ void FFunctionTranslator::Init(UFunction* InFunction, bool IsDelegate)
                         DefaultValuePtr = MetaMap->Find(Property->GetFName());
                         if (DefaultValuePtr && !DefaultValuePtr->IsEmpty())
                         {
+                            // LatentInfo="LatentInfo" identifies the latent parameter; it is not a valid struct default value.
+                            // Keep this runtime guard for metadata generated before the UHT exporter fix.
+                            if (Property->GetFName() == TEXT("LatentInfo") && *DefaultValuePtr == TEXT("LatentInfo"))
+                            {
+                                continue;
+                            }
                             // UE_LOG(LogTemp, Warning, TEXT("Meta %s %s"), *Property->GetFName().ToString(), **DefaultValuePtr);
                             if (!ArgumentDefaultValues)
                             {

--- a/unreal/Puerts/Source/Puerts/Private/PuertsModule.cpp
+++ b/unreal/Puerts/Source/Puerts/Private/PuertsModule.cpp
@@ -56,6 +56,7 @@ public:
 
     void PreBeginPIE(bool bIsSimulating);
     void EndPIE(bool bIsSimulating);
+    void EndPlayMap();
     bool HandleSettingsSaved();
 #endif
 
@@ -315,38 +316,46 @@ void FPuertsModule::PreBeginPIE(bool bIsSimulating)
 }
 void FPuertsModule::EndPIE(bool bIsSimulating)
 {
+    // UEditorEngine broadcasts EndPIE before TeardownPlaySession starts cleaning up play worlds.
+    // Keep the environment alive so JavaScript teardown can run during World and GameInstance deinitialization.
     bIsInPIE = false;
-    if (Enabled)
+}
+void FPuertsModule::EndPlayMap()
+{
+    if (!Enabled)
     {
-        JsEnv.Reset();
-        for (TObjectIterator<UClass> It; It; ++It)
+        return;
+    }
+
+    JsEnv.Reset();
+    JsEnvGroup.Reset();
+    for (TObjectIterator<UClass> It; It; ++It)
+    {
+        UClass* Class = *It;
+        if (auto TsClass = Cast<UTypeScriptGeneratedClass>(Class))
         {
-            UClass* Class = *It;
-            if (auto TsClass = Cast<UTypeScriptGeneratedClass>(Class))
+            TsClass->CancelRedirection();
+            TsClass->DynamicInvoker.Reset();
+        }
+        if (Class->ClassConstructor == UTypeScriptGeneratedClass::StaticConstructor)
+        {
+            auto SuperClass = Class->GetSuperClass();
+            while (SuperClass)
             {
-                TsClass->CancelRedirection();
-                TsClass->DynamicInvoker.Reset();
+                if (SuperClass->ClassConstructor != UTypeScriptGeneratedClass::StaticConstructor)
+                {
+                    Class->ClassConstructor = SuperClass->ClassConstructor;
+                    break;
+                }
+                SuperClass = SuperClass->GetSuperClass();
             }
             if (Class->ClassConstructor == UTypeScriptGeneratedClass::StaticConstructor)
             {
-                auto SuperClass = Class->GetSuperClass();
-                while (SuperClass)
-                {
-                    if (SuperClass->ClassConstructor != UTypeScriptGeneratedClass::StaticConstructor)
-                    {
-                        Class->ClassConstructor = SuperClass->ClassConstructor;
-                        break;
-                    }
-                    SuperClass = SuperClass->GetSuperClass();
-                }
-                if (Class->ClassConstructor == UTypeScriptGeneratedClass::StaticConstructor)
-                {
-                    Class->ClassConstructor = nullptr;
-                }
+                Class->ClassConstructor = nullptr;
             }
         }
-        UE_LOG(PuertsModule, Display, TEXT("JsEnv reset"));
     }
+    UE_LOG(PuertsModule, Display, TEXT("JsEnv reset after play worlds cleaned up"));
 }
 #endif
 
@@ -414,6 +423,7 @@ void FPuertsModule::StartupModule()
     {
         FEditorDelegates::PreBeginPIE.AddRaw(this, &FPuertsModule::PreBeginPIE);
         FEditorDelegates::EndPIE.AddRaw(this, &FPuertsModule::EndPIE);
+        FGameDelegates::Get().GetEndPlayMapDelegate().AddRaw(this, &FPuertsModule::EndPlayMap);
 
         // FEditorSupportDelegates::CleanseEditor.AddRaw(this, &FPuertsModule::CleanseEditor);
         // FLevelEditorModule& LevelEditor = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
@@ -502,6 +512,7 @@ void FPuertsModule::ShutdownModule()
 {
 #if WITH_EDITOR
     UnregisterSettings();
+    FGameDelegates::Get().GetEndPlayMapDelegate().RemoveAll(this);
     if (FLevelEditorModule* LevelEditor = FModuleManager::GetModulePtr<FLevelEditorModule>("LevelEditor"))
     {
         LevelEditor->OnMapChanged().RemoveAll(this);


### PR DESCRIPTION
本 PR 修复 Unreal 侧的两个问题：

1. Puerts 在 `FEditorDelegates::EndPIE` 阶段过早销毁模块级 JavaScript 环境，导致 World 和 GameInstance 的脚本清理可能在 JsEnv 已失效后执行；
2. C# UHT 默认参数生成器将 `LatentInfo="LatentInfo"` 元数据误识别为 `FLatentActionInfo` 的默认值，运行时因此出现 `ImportText` 错误。

两个问题分别放在独立提交中，便于审查和按需合入。

## 问题说明

### PIE World 清理前 JsEnv 已被销毁

`FEditorDelegates::EndPIE` 的广播时机早于 `UEditorEngine::TeardownPlaySession` 完成 Play World 清理。

原有实现会在收到 `EndPIE` 后立即执行 `JsEnv.Reset()`，并清理 TypeScript Generated Class 的重定向和动态调用器。但此时以下退出逻辑仍可能继续执行：

- World Subsystem 反初始化；
- GameInstance Subsystem 反初始化；
- UI、输入和委托解绑；
- JavaScript 侧资源释放。

这会导致脚本清理阶段访问已经销毁的运行环境。

原有 `EndPIE` 路径还有一个疏漏：只释放了 `JsEnv`，没有同步释放 `JsEnvGroup`。

### `LatentInfo` 元数据被当作默认参数

对于 Blueprint latent 函数，Unreal 使用如下元数据指定 latent 参数：

```text
LatentInfo="LatentInfo"
```

这里的值表示 latent 参数名称，不是 `FLatentActionInfo` 的序列化默认值。

C# 默认参数生成器会先按参数源码名称查询函数元数据。当参数名为 `LatentInfo` 时，该查询会错误命中上述元数据，并生成：

```cpp
__PF->Add(TEXT("LatentInfo"), TEXT("LatentInfo"));
```

`FFunctionTranslator` 随后将字符串传给 `ImportText`，产生错误：

```text
ImportText (LatentInfo): Missing opening parenthesis: LatentInfo
```

## 修改内容

### 调整 PIE 生命周期

- `EndPIE` 只更新 PIE 状态，不再销毁 JavaScript 环境；
- 将 `JsEnv`、`JsEnvGroup` 和 TypeScript Generated Class 重定向清理移动到 `FGameDelegates::GetEndPlayMapDelegate()`；
- 在模块关闭时对称解绑新增的 `EndPlayMap` 回调。

调整后的退出顺序为：

```text
EndPIE
→ World / GameInstance 退出及脚本清理
→ EndPlayMap
→ JsEnv、JsEnvGroup 和 Generated Class 清理
```

### 修正 latent 参数元数据

- C# UHT 生成器根据函数的 `LatentInfo` 元数据识别真实 latent 参数；
- 从默认参数生成结果中排除该参数；
- 在 `FFunctionTranslator` 中保留运行时兼容保护，跳过旧生成产物中的非法 `LatentInfo="LatentInfo"` 默认值。

两处改动各管一段：生成端修复保证新产物正确；运行时保护处理旧产物，修复前生成的 `InitParamDefaultMetas.inl` 在重新生成前不会再触发 `ImportText` 错误。

## 兼容性

- JsEnv 生命周期调整仅影响编辑器 PIE；
- 非编辑器环境的创建和关闭路径保持不变；
- `JsEnvGroup` 现在与单 JsEnv 使用相同的 PIE 回收时机；
- 运行时兼容保护可处理修复前生成的默认参数文件；
- 未增加项目定制接口，也未改变现有公开 API。