### PR TITLE
修复了在UE5.8下执行Puerts.Gen命令会重复生成UE编辑器侧动态类型的bug

### DIFF
--- a/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
+++ b/unreal/Puerts/Source/DeclarationGenerator/Private/DeclarationGenerator.cpp
@@ -65,6 +65,27 @@ static FAutoConsoleVariableRef CVarSearchAllPluginBP(TEXT("bSearchAllPluginBP"),
 #define GET_VERSION_ID(PD) PD->PackageGuid.ToString()
 #endif
 
+static bool ShouldSkipBlueprintDeclarationAsset(const FString& PackageNameOrPath)
+{
+    return PackageNameOrPath.StartsWith(TEXT("/Engine/TedsDynamicColumns"));
+}
+
+static bool ShouldSkipBlueprintDeclarationAsset(const FName& PackageNameOrPath)
+{
+    return ShouldSkipBlueprintDeclarationAsset(PackageNameOrPath.ToString());
+}
+
+static FString RestoreEscapedPackageNameFromNamespace(const FString& Namespace)
+{
+    TArray<FString> NamespaceFrags;
+    Namespace.ParseIntoArray(NamespaceFrags, TEXT("."));
+    for (FString& NamespaceFrag : NamespaceFrags)
+    {
+        NamespaceFrag = PUERTS_NAMESPACE::TypeScriptVariableNameToFilename(NamespaceFrag);
+    }
+    return FString(TEXT("/")) + FString::Join(NamespaceFrags, TEXT("/"));
+}
+
 bool IsTypeScriptKeyword(const FString& InputString)
 {
     static TArray<FString> TypeScriptKeywords = {TEXT("break"), TEXT("as"), TEXT("any"), TEXT("switch"), TEXT("case"), TEXT("if"),
@@ -436,6 +457,10 @@ void FTypeScriptDeclarationGenerator::GenTypeScriptDeclaration(bool InGenStruct,
     Begin();
     for (auto& KV : BlueprintTypeDeclInfoCache)
     {
+        if (ShouldSkipBlueprintDeclarationAsset(KV.Key))
+        {
+            continue;
+        }
         if (KV.Value.IsExist)
         {
             for (auto& NameToDecl : KV.Value.NameToDecl)
@@ -532,6 +557,11 @@ void FTypeScriptDeclarationGenerator::WriteOutput(UObject* Obj, const FStringBuf
     const UPackage* Pkg = GetPackage(Obj);
     if (Pkg && !Obj->IsNative())
     {
+        if (ShouldSkipBlueprintDeclarationAsset(Pkg->GetFName()))
+        {
+            return;
+        }
+
         FStringBuffer Temp;
         Temp.Prefix = Output.Prefix;
         NamespaceBegin(Obj, Temp);
@@ -592,27 +622,29 @@ void FTypeScriptDeclarationGenerator::RestoreBlueprintTypeDeclInfos(const FStrin
                     FString Namespace =
                         TypeDecl.Mid(NamespaceStart + NS_Keyword.Len(), NamespaceEnd - NamespaceStart - NS_Keyword.Len())
                             .TrimStartAndEnd();
-                    FString PackageName = FString(TEXT("/")) + Namespace.Replace(TEXT("."), TEXT("/"));
-
-                    FRegexPattern Pattern(TEXT("\\{\\s+(?:(?:class)|(?:enum))\\s+([\\u4e00-\\u9fa5a-zA-Z0-9_]+)"));
-                    FRegexMatcher Matcher(Pattern, TypeDecl.Mid(NamespaceEnd));
-
-                    if (Matcher.FindNext())
+                    FString PackageName = RestoreEscapedPackageNameFromNamespace(Namespace);
+                    if (!ShouldSkipBlueprintDeclarationAsset(PackageName))
                     {
-                        FName TypeName = *Matcher.GetCaptureGroup(1);
-                        auto BlueprintTypeDeclInfoPtr = BlueprintTypeDeclInfoCache.Find(*PackageName);
+                        FRegexPattern Pattern(TEXT("\\{\\s+(?:(?:class)|(?:enum))\\s+([\\u4e00-\\u9fa5a-zA-Z0-9_$]+)"));
+                        FRegexMatcher Matcher(Pattern, TypeDecl.Mid(NamespaceEnd));
 
-                        if (BlueprintTypeDeclInfoPtr)
+                        if (Matcher.FindNext())
                         {
-                            BlueprintTypeDeclInfoPtr->NameToDecl.Add(TypeName, TypeDecl);
-                        }
-                        else
-                        {
-                            TMap<FName, FString> NameToDecl;
-                            NameToDecl.Add(TypeName, TypeDecl);
-                            bool bIsExist = InGenFull ? false : bIsAssociation;
-                            BlueprintTypeDeclInfoCache.Add(
-                                FName(*PackageName), {NameToDecl, FileVersionString, bIsExist, true, bIsAssociation});
+                            FName TypeName = *PUERTS_NAMESPACE::TypeScriptVariableNameToFilename(Matcher.GetCaptureGroup(1));
+                            auto BlueprintTypeDeclInfoPtr = BlueprintTypeDeclInfoCache.Find(*PackageName);
+
+                            if (BlueprintTypeDeclInfoPtr)
+                            {
+                                BlueprintTypeDeclInfoPtr->NameToDecl.Add(TypeName, TypeDecl);
+                            }
+                            else
+                            {
+                                TMap<FName, FString> NameToDecl;
+                                NameToDecl.Add(TypeName, TypeDecl);
+                                bool bIsExist = InGenFull ? false : bIsAssociation;
+                                BlueprintTypeDeclInfoCache.Add(
+                                    FName(*PackageName), {NameToDecl, FileVersionString, bIsExist, true, bIsAssociation});
+                            }
                         }
                     }
                 }
@@ -661,6 +693,12 @@ void FTypeScriptDeclarationGenerator::LoadAllWidgetBlueprint(FName InSearchPath,
     AssetRegistry.GetAssets(BPFilter, AssetList);
     for (FAssetData const& AssetData : AssetList)
     {
+        if (ShouldSkipBlueprintDeclarationAsset(AssetData.PackageName) ||
+            ShouldSkipBlueprintDeclarationAsset(AssetData.PackagePath))
+        {
+            continue;
+        }
+
 #if ENGINE_MAJOR_VERSION >= 5
         const FAssetPackageData* PackageData = nullptr;
         auto OptionalPackageData = AssetRegistry.GetAssetPackageDataCopy(AssetData.PackageName);


### PR DESCRIPTION
我在UE5.8下当项目根目录中已存在 Typing/ue/ue_bp.d.ts 类型声明文件时，再次执行 `Puerts.Gen` 命令会重复生成编辑器侧的动态类型，如下：
```
Typing/ue/ue_bp.d.ts:45520:15 - error TS2300: Duplicate identifier 'EditorDataStorageTableDynamicTag$58$$58$Property$32$Information'.
45520         class EditorDataStorageTableDynamicTag$58$$58$Property$32$Information extends UE.EditorDataStorageTableDynamicTag {
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Typing/ue/ue_bp.d.ts:45535:15 - error TS2300: Duplicate identifier 'EditorDataStorageTableDynamicTag$58$$58$Type$32$Information'.
45535         class EditorDataStorageTableDynamicTag$58$$58$Type$32$Information extends UE.EditorDataStorageTableDynamicTag {
```

大概率是因为 UE5.8 引入/暴露的编辑器侧动态类型有关，Puerts 自己做的“非法 TS 标识符转义”。
主要可能是 UE5.8 里多了更容易被资产注册表枚举到这些 `Engine.TedsDynamicColumns` 相关的动态类型，比如：
```
EditorDataStorageTableDynamicTag::Alerts chain
EditorDataStorageTableDynamicTag::Property Information
SettingsModuleTag::Magnate
```

为此，我做了两件事：修复 ue_bp.d.ts 第二次生成重复声明的根因，并过滤不需要的 UE5.8 编辑器动态类型。

- 根因修复放在 `DeclarationGenerator.cpp` 的恢复缓存逻辑中。

- 过滤逻辑放在资产注册表枚举阶段，优先跳过 `/Engine/TedsDynamicColumns`，减少无用声明。

关键修改

- 修复 `RestoreBlueprintTypeDeclInfos`：
    - 从 `.d.ts` 恢复 namespace 时，对每个 namespace 片段调用 `PUERTS_NAMESPACE::TypeScriptVariableNameToFilename`，再组装真实 package path。

    - class/enum 名称正则增加 `$` 支持，完整捕获 `$58$`、`$32$` 这类转义名。
    - 恢复出的类型名也调用 `TypeScriptVariableNameToFilename`，确保 `NameToDecl` 的 key 和 `WriteOutput` 的 `Obj->GetFName()` 一致。

- 增加资产过滤：
    - 在 `LoadAllWidgetBlueprint` 遍历 `AssetList` 时跳过 `AssetData.PackagePath` 或 `AssetData.PackageName` 以 `/Engine/TedsDynamicColumns` 开头的资产。
    - 对已从旧 `ue_bp.d.ts` 恢复出的 `/Engine/TedsDynamicColumns` 缓存项也跳过输出或标记为不存在，避免历史污染继续保留。

- 保持 `FFileHelper::SaveStringToFile` 覆盖写行为不变。

实现细节
- 增加一个小函数，例如 `RestoreEscapedPackageNameFromNamespace`：
    - 输入：`Engine.TedsDynamicColumns.EditorDataStorageTableDynamicTag_Alerts$32$chain`
    - 输出：`/Engine/TedsDynamicColumns/EditorDataStorageTableDynamicTag_Alerts chain`

- 增加一个小函数，例如 `ShouldSkipBlueprintDeclarationAsset`：
    - 默认返回 true 的路径：`/Engine/TedsDynamicColumns`
    - 同时用于资产枚举过滤和恢复缓存输出过滤，避免两处规则不一致。

- 对过滤命中项不生成、不保留旧声明；业务项目 /Game 和项目插件内容不受影响。