### PR TITLE
fix(unreal): guard TS blueprint gen against missing GeneratedClass

### DIFF
--- a/unreal/Puerts/Content/JavaScript/PuertsEditor/CodeAnalyze.js
+++ b/unreal/Puerts/Content/JavaScript/PuertsEditor/CodeAnalyze.js
@@ -602,8 +602,15 @@ function watch(configFilePath) {
                         let moduleFileName = sourceFileName.substr(options.outDir.length + 1);
                         let modulePath = tsi.getDirectoryPath(moduleFileName);
                         let bp = new UE.PEBlueprintAsset();
-                        bp.LoadOrCreate(type.getSymbol().getName(), modulePath, baseTypeUClass, 0, 0);
+                        if (!bp.LoadOrCreate(type.getSymbol().getName(), modulePath, baseTypeUClass, 0, 0)) {
+                            console.error(`[CodeAnalyze] can not load or create blueprint for [${type.symbol.getName()}], skip using it as a base class`);
+                            return undefined;
+                        }
                         bp.Save();
+                        if (!bp.GeneratedClass) {
+                            console.error(`[CodeAnalyze] blueprint of [${type.symbol.getName()}] has no generated class after saving, skip using it as a base class`);
+                            return undefined;
+                        }
                         return bp.GeneratedClass;
                     }
                 }
@@ -817,7 +824,11 @@ function watch(configFilePath) {
             function onBlueprintTypeAddOrChange(baseTypeUClass, type, modulePath) {
                 let lsFunctionLibrary = baseTypeUClass && baseTypeUClass.GetName() === "BlueprintFunctionLibrary";
                 let bp = new UE.PEBlueprintAsset();
-                bp.LoadOrCreateWithMetaData(type.getSymbol().getName(), modulePath, baseTypeUClass, 0, 0, uemeta.compileClassMetaData(type));
+                if (!bp.LoadOrCreateWithMetaData(type.getSymbol().getName(), modulePath, baseTypeUClass, 0, 0, uemeta.compileClassMetaData(type))) {
+                    // Continuing would call AddFunction/AddMemberVariable against a null GeneratedClass and crash the editor.
+                    console.error(`[CodeAnalyze] can not load or create blueprint for [${type.getSymbol().getName()}], skip generating it`);
+                    return;
+                }
                 let hasConstructor = false;
                 let properties = [];
                 type.symbol.valueDeclaration.forEachChild(x => {

--- a/unreal/Puerts/PuertsEditor/CodeAnalyze.ts
+++ b/unreal/Puerts/PuertsEditor/CodeAnalyze.ts
@@ -704,8 +704,15 @@ function watch(configFilePath:string) {
                         let moduleFileName = sourceFileName.substr(options.outDir.length + 1);
                         let modulePath = tsi.getDirectoryPath(moduleFileName);
                         let bp = new UE.PEBlueprintAsset();
-                        bp.LoadOrCreate(type.getSymbol().getName(), modulePath, baseTypeUClass as UE.Class, 0, 0);
+                        if (!bp.LoadOrCreate(type.getSymbol().getName(), modulePath, baseTypeUClass as UE.Class, 0, 0)) {
+                            console.error(`[CodeAnalyze] can not load or create blueprint for [${type.symbol.getName()}], skip using it as a base class`);
+                            return undefined;
+                        }
                         bp.Save();
+                        if (!bp.GeneratedClass) {
+                            console.error(`[CodeAnalyze] blueprint of [${type.symbol.getName()}] has no generated class after saving, skip using it as a base class`);
+                            return undefined;
+                        }
                         return bp.GeneratedClass;
                     }
                 }
@@ -937,7 +944,11 @@ function watch(configFilePath:string) {
                 console.log(`gen blueprint for ${type.getSymbol().getName()}, path: ${modulePath}`);
                 let lsFunctionLibrary:boolean =  baseTypeUClass && baseTypeUClass.GetName() === "BlueprintFunctionLibrary";
                 let bp = new UE.PEBlueprintAsset();
-                bp.LoadOrCreateWithMetaData(type.getSymbol().getName(), modulePath, baseTypeUClass, 0, 0, uemeta.compileClassMetaData(type));
+                if (!bp.LoadOrCreateWithMetaData(type.getSymbol().getName(), modulePath, baseTypeUClass, 0, 0, uemeta.compileClassMetaData(type))) {
+                    // Continuing would call AddFunction/AddMemberVariable against a null GeneratedClass and crash the editor.
+                    console.error(`[CodeAnalyze] can not load or create blueprint for [${type.getSymbol().getName()}], skip generating it`);
+                    return;
+                }
                 let hasConstructor = false;
                 let properties: ts.Symbol[] = [];
                 type.symbol.valueDeclaration.forEachChild(x  => {

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -58,7 +58,7 @@ static bool IsPlaying()
     if (IsPlaying())                                                                                       \
     {                                                                                                      \
         UE_LOG(PuertsEditorModule, Error, TEXT("change the layout of class[%s] in PIE mode is forbiden!"), \
-            *GeneratedClass->GetName());                                                                   \
+            *GetNameSafe(GeneratedClass));                                                                 \
         NeedSave = false;                                                                                  \
         return false;                                                                                      \
     }
@@ -67,10 +67,25 @@ static bool IsPlaying()
     if (IsPlaying())                                                                                       \
     {                                                                                                      \
         UE_LOG(PuertsEditorModule, Error, TEXT("change the layout of class[%s] in PIE mode is forbiden!"), \
-            *GeneratedClass->GetName());                                                                   \
+            *GetNameSafe(GeneratedClass));                                                                 \
         NeedSave = false;                                                                                  \
         return;                                                                                            \
     }
+
+bool UPEBlueprintAsset::IsAssetReady(const TCHAR* InOperation)
+{
+    if (IsValid(Blueprint) && IsValid(GeneratedClass))
+    {
+        return true;
+    }
+
+    // LoadOrCreate[WithMetaData] failed (or was refused in PIE mode) and left this asset half initialized. The
+    // TypeScript side drives every Add*/Setup* call unconditionally, so bail out instead of dereferencing null.
+    UE_LOG(PuertsEditorModule, Error, TEXT("%s skipped: blueprint asset is not ready (blueprint[%s], generated class[%s])"),
+        InOperation, *GetNameSafe(Blueprint), *GetNameSafe(GeneratedClass));
+    NeedSave = false;
+    return false;
+}
 
 bool UPEBlueprintAsset::Existed(const FString& InName, const FString& InPath)
 {
@@ -95,22 +110,87 @@ bool UPEBlueprintAsset::LoadOrCreate(
     if (Blueprint)
     {
         GeneratedClass = Blueprint->GeneratedClass;
-        if (auto TypeScriptGeneratedClass = Cast<UTypeScriptGeneratedClass>(GeneratedClass))
+        if (IsValid(GeneratedClass))
         {
-            HasConstructor = TypeScriptGeneratedClass->HasConstructor;
+            if (auto TypeScriptGeneratedClass = Cast<UTypeScriptGeneratedClass>(GeneratedClass))
+            {
+                HasConstructor = TypeScriptGeneratedClass->HasConstructor;
+            }
+            Package = Cast<UPackage>(Blueprint->GetOuter());
+            if (Blueprint->ParentClass != ParentClass)
+            {
+                // Normal TypeScript reparent: old parent still loads, just retarget and let Save recompile.
+                CanChangeCheckWithBoolRet();
+                Blueprint->ParentClass = ParentClass;
+                NeedSave = true;
+            }
+            else
+            {
+                NeedSave = false;
+            }
+            return true;
         }
-        Package = Cast<UPackage>(Blueprint->GetOuter());
-        if (Blueprint->ParentClass != ParentClass)
+
+        // Stale asset: the parent class recorded in the .uasset failed to load, so GeneratedClass never came up
+        // (see the LogLinker "both will fail to load" warnings). If TypeScript already points at a live ParentClass,
+        // tear the broken asset down and fall through to recreate - otherwise users could not recover by changing
+        // the TS base class. With no replacement parent there is nothing we can safely do.
+        if (!IsValid(ParentClass))
         {
-            CanChangeCheckWithBoolRet();
-            Blueprint->ParentClass = ParentClass;
-            NeedSave = true;
-        }
-        else
-        {
+            UE_LOG(PuertsEditorModule, Error,
+                TEXT("blueprint [%s] has no valid generated class and no replacement parent was provided, skip"), *PackageName);
+            Blueprint = nullptr;
+            GeneratedClass = nullptr;
             NeedSave = false;
+            return false;
         }
-        return true;
+
+        if (IsPlaying())
+        {
+            UE_LOG(PuertsEditorModule, Error,
+                TEXT("blueprint [%s] is broken (missing generated class) but recreating in PIE mode is forbiden!"), *PackageName);
+            Blueprint = nullptr;
+            GeneratedClass = nullptr;
+            NeedSave = false;
+            return false;
+        }
+
+        UE_LOG(PuertsEditorModule, Warning,
+            TEXT("blueprint [%s] has no valid generated class (recorded parent failed to load). Recreating under parent [%s]"),
+            *PackageName, *ParentClass->GetName());
+
+        FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry"));
+        AssetRegistryModule.Get().AssetDeleted(Blueprint);
+
+        // Move the broken object out of the package so CreateBlueprint can reuse the same asset name.
+        const FString TrashName = InName + TEXT("__Broken_") + FGuid::NewGuid().ToString(EGuidFormats::Digits);
+        Blueprint->ClearFlags(RF_Standalone | RF_Public);
+        Blueprint->Rename(*TrashName, GetTransientPackage(),
+            REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders | REN_NonTransactional);
+        Blueprint->RemoveFromRoot();
+#if ENGINE_MAJOR_VERSION >= 5
+        Blueprint->MarkAsGarbage();
+#else
+        Blueprint->MarkPendingKill();
+#endif
+        Blueprint = nullptr;
+        GeneratedClass = nullptr;
+        Package = nullptr;
+
+        FString AssetFilePath = FString(TEXT(TS_BLUEPRINT_PATH)) / InPath / InName + TEXT(".uasset");
+        if (AssetFilePath[0] == TEXT('/') || AssetFilePath[0] == TEXT('\\'))
+        {
+            AssetFilePath = AssetFilePath.Mid(1);
+        }
+        AssetFilePath = FPaths::ProjectContentDir() / AssetFilePath;
+        IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+        if (PlatformFile.FileExists(*AssetFilePath) && !PlatformFile.DeleteFile(*AssetFilePath))
+        {
+            UE_LOG(PuertsEditorModule, Error, TEXT("Failed to delete broken TypeScript blueprint asset: %s"), *AssetFilePath);
+            NeedSave = false;
+            return false;
+        }
+        // Fall through to the create path below with the caller's ParentClass.
     }
 
     if (!ParentClass)
@@ -161,6 +241,14 @@ bool UPEBlueprintAsset::LoadOrCreate(
         // Mark the package dirty...
         Package->MarkPackageDirty();
         GeneratedClass = Blueprint->GeneratedClass;
+        if (!IsValid(GeneratedClass))
+        {
+            UE_LOG(PuertsEditorModule, Error, TEXT("blueprint [%s] was created without a valid generated class"), *PackageName);
+            Blueprint = nullptr;
+            GeneratedClass = nullptr;
+            NeedSave = false;
+            return false;
+        }
         return true;
     }
     else
@@ -394,6 +482,12 @@ UClass* const GetOverrideFunctionClass(UBlueprint* Blueprint, const FName FuncNa
 void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType InGraphPinType, FPEGraphTerminalType InPinValueType,
     int32 InSetFlags, int32 InClearFlags)
 {
+    if (!IsAssetReady(TEXT("AddFunction")))
+    {
+        ClearParameter();
+        return;
+    }
+
     InSetFlags &= ~InClearFlags;
     InSetFlags &= ~FUNC_Native;
     const int32 NetMask = FUNC_Net | FUNC_NetMulticast | FUNC_NetServer | FUNC_NetClient | FUNC_NetReliable;
@@ -404,7 +498,7 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
 
     UClass* SuperClass = GeneratedClass->GetSuperClass();
 
-    UFunction* ParentFunction = SuperClass->FindFunctionByName(InName);
+    UFunction* ParentFunction = SuperClass ? SuperClass->FindFunctionByName(InName) : nullptr;
 
     UFunction* Function = GeneratedClass->FindFunctionByName(InName, EIncludeSuperFlag::ExcludeSuper);
 
@@ -856,6 +950,12 @@ void UPEBlueprintAsset::AddFunctionWithMetaData(FName InName, bool IsVoid, FPEGr
      * @brief
      *		function body
      */
+    if (!IsAssetReady(TEXT("AddFunctionWithMetaData")))
+    {
+        ClearParameter();
+        return;
+    }
+
     if (IsValid(InMetaData))
     {
         InSetFlags |= static_cast<int32>(InMetaData->FunctionFlags);
@@ -895,6 +995,11 @@ void UPEBlueprintAsset::ClearParameter()
 
 void UPEBlueprintAsset::RemoveComponent(FName ComponentName)
 {
+    if (!IsValid(Blueprint) || !Blueprint->SimpleConstructionScript)
+    {
+        return;
+    }
+
     auto SCS_Node = Blueprint->SimpleConstructionScript->FindSCSNode(ComponentName);
     if (SCS_Node)
     {
@@ -970,6 +1075,11 @@ void UPEBlueprintAsset::RemoveComponent(FName ComponentName)
 
 void UPEBlueprintAsset::SetupAttachment(FName InComponentName, FName InParentComponentName)
 {
+    if (!IsValid(Blueprint))
+    {
+        return;
+    }
+
     if (Blueprint->SimpleConstructionScript)
     {
         auto SCS_Node = Blueprint->SimpleConstructionScript->FindSCSNode(InComponentName);
@@ -1017,6 +1127,11 @@ void UPEBlueprintAsset::SetupAttachment(FName InComponentName, FName InParentCom
 
 void UPEBlueprintAsset::SetupAttachments(TMap<FName, FName> InAttachments)
 {
+    if (!IsAssetReady(TEXT("SetupAttachments")))
+    {
+        return;
+    }
+
     if (Blueprint->SimpleConstructionScript)
     {
         for (auto& KV : InAttachments)
@@ -1050,6 +1165,11 @@ void UPEBlueprintAsset::SetupAttachments(TMap<FName, FName> InAttachments)
 void UPEBlueprintAsset::AddMemberVariable(FName NewVarName, FPEGraphPinType InGraphPinType, FPEGraphTerminalType InPinValueType,
     int32 InLFlags, int32 InHFlags, int32 InLifetimeCondition)
 {
+    if (!IsAssetReady(TEXT("AddMemberVariable")))
+    {
+        return;
+    }
+
     uint64 InFlags = (uint64) InHFlags << 32 | InLFlags;
     FEdGraphPinType PinType = ToFEdGraphPinType(InGraphPinType, InPinValueType);
 
@@ -1057,7 +1177,7 @@ void UPEBlueprintAsset::AddMemberVariable(FName NewVarName, FPEGraphPinType InGr
     {
         if (auto ComponentClass = Cast<UClass>(PinType.PinSubCategoryObject))
         {
-            if (Blueprint->GeneratedClass->IsChildOf<AActor>() && Blueprint->SimpleConstructionScript &&
+            if (GeneratedClass->IsChildOf<AActor>() && Blueprint->SimpleConstructionScript &&
                 PinType.PinCategory == UEdGraphSchema_K2::PC_Object &&
                 (ComponentClass == UActorComponent::StaticClass() || ComponentClass->IsChildOf<UActorComponent>()))
             {
@@ -1183,6 +1303,11 @@ void UPEBlueprintAsset::AddMemberVariable(FName NewVarName, FPEGraphPinType InGr
 void UPEBlueprintAsset::AddMemberVariableWithMetaData(FName InNewVarName, FPEGraphPinType InGraphPinType,
     FPEGraphTerminalType InPinValueType, int32 InLFlags, int32 InHFLags, int32 InLifetimeCondition, UPEPropertyMetaData* InMetaData)
 {
+    if (!IsAssetReady(TEXT("AddMemberVariableWithMetaData")))
+    {
+        return;
+    }
+
     if (IsValid(InMetaData))
     {    //	handle the conflict here
         EPropertyFlags InputFlags = static_cast<EPropertyFlags>((static_cast<uint64>(InHFLags) << 32) + InLFlags);
@@ -1356,38 +1481,54 @@ void UPEBlueprintAsset::Save()
             FBlueprintEditorUtils::MarkBlueprintAsModified(Blueprint);
             FKismetEditorUtilities::CompileBlueprint(Blueprint);
 
-            for (TFieldIterator<UFunction> FuncIt(TypeScriptGeneratedClass, EFieldIteratorFlags::ExcludeSuper); FuncIt; ++FuncIt)
+            // Compiling may reinstance the class: the previous UClass is trashed while the blueprint points at a
+            // freshly created one. Refresh the cached pointer, otherwise derived TypeScript classes that take
+            // GeneratedClass as their parent keep a dead class.
+            GeneratedClass = Blueprint->GeneratedClass;
+            TypeScriptGeneratedClass = Cast<UTypeScriptGeneratedClass>(GeneratedClass);
+
+            if (IsValid(TypeScriptGeneratedClass))
             {
-                auto Function = *FuncIt;
-                Function->FunctionFlags &= ~FUNC_Native;
-
-                auto FunctionFName = Function->GetFName();
-                FString FunctionName = Function->GetName();
-
-                static FString AxisPrefix(TEXT("InpAxisEvt_"));
-                if (FunctionName.StartsWith(AxisPrefix))
+                for (TFieldIterator<UFunction> FuncIt(TypeScriptGeneratedClass, EFieldIteratorFlags::ExcludeSuper); FuncIt;
+                     ++FuncIt)
                 {
-                    auto FunctionNameWithoutPrefix = FunctionName.Mid(AxisPrefix.Len());
-                    int32 SubPos;
-                    if (FunctionNameWithoutPrefix.FindChar('_', SubPos))
+                    auto Function = *FuncIt;
+                    Function->FunctionFlags &= ~FUNC_Native;
+
+                    auto FunctionFName = Function->GetFName();
+                    FString FunctionName = Function->GetName();
+
+                    static FString AxisPrefix(TEXT("InpAxisEvt_"));
+                    if (FunctionName.StartsWith(AxisPrefix))
                     {
-                        FunctionName = FunctionNameWithoutPrefix.Mid(0, SubPos);
+                        auto FunctionNameWithoutPrefix = FunctionName.Mid(AxisPrefix.Len());
+                        int32 SubPos;
+                        if (FunctionNameWithoutPrefix.FindChar('_', SubPos))
+                        {
+                            FunctionName = FunctionNameWithoutPrefix.Mid(0, SubPos);
+                        }
+                    }
+                    static FString ActionPrefix(TEXT("InpActEvt_"));
+                    if (FunctionName.StartsWith(ActionPrefix))
+                    {
+                        auto FunctionNameWithoutPrefix = FunctionName.Mid(ActionPrefix.Len());
+                        int32 SubPos;
+                        if (FunctionNameWithoutPrefix.FindChar('_', SubPos))
+                        {
+                            FunctionName = FunctionNameWithoutPrefix.Mid(0, SubPos);
+                        }
+                    }
+                    if (FunctionAdded.Contains(*FunctionName))
+                    {
+                        TypeScriptGeneratedClass->FunctionToRedirect.Add(FunctionFName);
                     }
                 }
-                static FString ActionPrefix(TEXT("InpActEvt_"));
-                if (FunctionName.StartsWith(ActionPrefix))
-                {
-                    auto FunctionNameWithoutPrefix = FunctionName.Mid(ActionPrefix.Len());
-                    int32 SubPos;
-                    if (FunctionNameWithoutPrefix.FindChar('_', SubPos))
-                    {
-                        FunctionName = FunctionNameWithoutPrefix.Mid(0, SubPos);
-                    }
-                }
-                if (FunctionAdded.Contains(*FunctionName))
-                {
-                    TypeScriptGeneratedClass->FunctionToRedirect.Add(FunctionFName);
-                }
+            }
+            else
+            {
+                UE_LOG(PuertsEditorModule, Error,
+                    TEXT("blueprint [%s] has no valid generated class after compiling, function redirection is skipped"),
+                    *GetNameSafe(Blueprint));
             }
 
             TArray<UPackage*> PackagesToSave;

--- a/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintAsset.h
+++ b/unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintAsset.h
@@ -175,6 +175,13 @@ public:
     void Save();
 
 private:
+    /**
+     * @brief Whether Blueprint / GeneratedClass are usable, i.e. a previous LoadOrCreate[WithMetaData] succeeded.
+     *        Logs and returns false otherwise, so the TypeScript driven Add / Setup calls degrade instead of crashing.
+     * @param InOperation Name of the caller, used for the error log only
+     */
+    bool IsAssetReady(const TCHAR* InOperation);
+
     TSet<FName> ComponentsAdded;
 
     TSet<FName> MemberVariableAdded;


### PR DESCRIPTION
修复编辑器在生成 TypeScript 蓝图时，因 `GeneratedClass` 为空而在 `UPEBlueprintAsset::AddFunction` 中空指针崩溃的问题。

当磁盘上已有陈旧的 TS 蓝图资产，且其记录的父类已无法加载时，`LoadOrCreate` 仍会“成功”返回，随后 `CodeAnalyze` 继续调用 `AddFunctionWithMetaData`，最终在 `GeneratedClass->GetSuperClass()` 处以访问违例崩溃（读地址形如 `0x38`，对应 `UStruct::SuperStruct` 偏移）。

## 问题描述

`CodeAnalyze` 在编辑器启动或 TypeScript 源码变更时，会为继承 UE Native 类型的 TS 类生成/更新蓝图资产，流程大致为：

1. `LoadOrCreateWithMetaData(...)`
2. 遍历方法/属性，调用 `AddFunctionWithMetaData` / `AddMemberVariableWithMetaData`
3. `Save()` → 编译并写回 `.uasset`

典型复现链：

1. 开始为某个 TS 类生成蓝图
2. Linker 报错：旧 `.uasset` 记录的父类加载失败，`TypeScriptGeneratedClass` 与其父类 “both will fail to load”
3. 默认对象也无法加载，因为 generated class 不存在
4. 紧接着崩溃：

```text
Unhandled Exception: EXCEPTION_ACCESS_VIOLATION reading address 0x0000000000000038
UClass::GetSuperClass()
UPEBlueprintAsset::AddFunction()
UPEBlueprintAsset::execAddFunctionWithMetaData()
```

根因不是随机内存破坏，而是空指针未保护：

1. 旧 `.uasset` 记录的父类（例如已被删除或重命名的 Native 类）加载失败
2. `Blueprint` 可能半载成功，但 `GeneratedClass` 为空
3. 旧版 `LoadOrCreate` 仍 `return true`
4. JS 侧忽略返回值，继续调用 `AddFunctionWithMetaData`
5. `GeneratedClass->GetSuperClass()` 对空指针解引用并崩溃

同一文件中，`Save` / `RemoveNotExisted*` 已有空指针判断，而 `AddFunction` / `AddMemberVariable` / `SetupAttachment*` 等生成路径缺少入口防护。

此外，即便勉强避免崩溃，用户把 TS 基类改到一个仍然有效的父类后，也会被坏掉的旧资产卡住，无法自动恢复。

## 解决方案

### 1. C++：`UPEBlueprintAsset` 入口防护

- 新增 `IsAssetReady()`：在 `Blueprint` / `GeneratedClass` 无效时打错误日志并早退
- `AddFunction` / `AddFunctionWithMetaData` / `AddMemberVariable*` / `SetupAttachments` 等调用点统一检查
- `AddFunction` 中对 `SuperClass` 做空判断
- `CanChangeCheck*` 宏改用 `GetNameSafe(GeneratedClass)`，避免保护逻辑自身二次崩溃

### 2. C++：`LoadOrCreate` 正确处理坏资产

- `GeneratedClass` 无效时不再假装成功
- 若调用方已提供有效的新 `ParentClass`（TS 已换到仍然可加载的基类）：
  - 从 AssetRegistry 注销旧资产
  - 将坏对象 Rename 到 Transient，移出原 Package
  - 删除磁盘 `.uasset`
  - 落到创建路径，用新父类重建
- 若没有可用父类，或处于 PIE：明确失败返回，而不是带着空 `GeneratedClass` 继续

这样既避免编辑器崩溃，也保留“修改 TS 基类即可恢复”的工作流，无需手动删除坏资产。

### 3. C++：`Save()` 编译后刷新缓存

`CompileBlueprint` 可能 reinstance 类，旧 `UClass` 会被标记为无效。  
编译后重新从 `Blueprint->GeneratedClass` 刷新缓存指针，避免把失效类继续当作派生 TS 类的父类往下传。

### 4. JS/TS：`CodeAnalyze` 检查返回值

- `getUClassOfType` 中 `LoadOrCreate` 失败或 `GeneratedClass` 为空时跳过，不再把它当作基类使用
- `onBlueprintTypeAddOrChange` 中 `LoadOrCreateWithMetaData` 失败时直接 return，不再继续 `AddFunction`

同步修改了源码与运行时产物：

- `PuertsEditor/CodeAnalyze.ts`
- `Content/JavaScript/PuertsEditor/CodeAnalyze.js`

## 修改文件

- `unreal/Puerts/Source/PuertsEditor/Public/PEBlueprintAsset.h`
- `unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp`
- `unreal/Puerts/PuertsEditor/CodeAnalyze.ts`
- `unreal/Puerts/Content/JavaScript/PuertsEditor/CodeAnalyze.js`

## 兼容性说明

- `MarkAsGarbage` / `MarkPendingKill` 按 UE5 / UE4 分支处理
- 未引入业务项目特有逻辑