### PR TITLE
android 16K Pagesize for the 3.x native projects

### DIFF
--- a/unity/native/papi-quickjs/CMakeLists.txt
+++ b/unity/native/papi-quickjs/CMakeLists.txt
@@ -177,3 +177,7 @@ target_compile_options(PapiQuickjs PRIVATE
         /GR-   # 禁用RTTI
     >
 )
+
+if ( ANDROID )
+    target_link_options(PapiQuickjs PRIVATE -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384) # android 16K Pagesize
+endif ()

--- a/unity/native/puerts/CMakeLists.txt
+++ b/unity/native/puerts/CMakeLists.txt
@@ -64,4 +64,8 @@ target_compile_options(PuertsCore PRIVATE
     >
 )
 
+if ( ANDROID )
+    target_link_options(PuertsCore PRIVATE -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384) # android 16K Pagesize
+endif ()
+
 install(TARGETS PuertsCore DESTINATION ${PROJECT_SOURCE_DIR}/lib)

--- a/unity/native/wsppaddon/CMakeLists.txt
+++ b/unity/native/wsppaddon/CMakeLists.txt
@@ -240,6 +240,7 @@ elseif ( ANDROID )
     if ( CMAKE_BUILD_TYPE MATCHES "Release" )
         target_link_options(WSPPAddon PRIVATE -s)
     endif ()
+    target_link_options(WSPPAddon PRIVATE -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384) # android 16K Pagesize
 elseif ( APPLE )
 
     if ( IOS )


### PR DESCRIPTION
### What

Adds the 16 KB page size linker flags to the three 3.x Unity native projects:

```cmake
target_link_options(<Target> PRIVATE -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384)
```

### Why

Google Play requires 16 KB page size support for apps targeting Android 15+, so every 64-bit `.so` has to be linked with 16 KB aligned segments.

This was already fixed for 2.x in 7d12275 ("android 16K Pagesize"), which added these same two flags to `unity/native_src/CMakeLists.txt` and shipped as the `Unity_v2.2.2_16kb` release. 3.x replaced that single project with `unity/native/{puerts,papi-quickjs,wsppaddon}`, one `CMakeLists.txt` each, and the flags were not carried over — so the 3.x plugins are back to 4 KB alignment.

Measured on the `Unity_v3.0.2` release binaries:

| library | arm64-v8a | x86_64 |
|---|---|---|
| `libPuertsCore.so` | `0x1000` | `0x1000` |
| `libPapiQuickjs.so` | `0x1000` | `0x1000` |
| `libWSPPAddon.so` | `0x1000` | `0x1000` |

An app that ships these is rejected by Google Play. In our case these three were the only libraries out of 18 in the APK that were not already 16 KB aligned — everything Unity itself produces already is.

Related: #2222, #2056.

### Why the flags and not a newer NDK

NDK r28 is the first release where 16 KB alignment is the default, so bumping the NDK would also work. But `.github/workflows/composites/unity-build-plugins/android/action.yml` pins `ANDROID_NDK=~/android-ndk-r27d`, and `unity/cli/make.mjs` defaults to the same. The explicit flags fix it on r27d and stay correct after a future NDK bump, so they seemed like the safer change. Happy to do it the other way if you would rather bump the NDK.

### Verification

Built `puerts`, `papi-quickjs` and `wsppaddon` for `android/arm64` and `android/x64` with NDK r27d:

- every `PT_LOAD` segment of all three libraries becomes `0x4000`
- exported dynamic symbols unchanged: 183 (`libPuertsCore`), 3371 (`libWSPPAddon`), 483 (`libPapiQuickjs`)
- `DT_NEEDED` unchanged, including `libPapiQuickjs.so -> libPuertsCore.so`
- sizes within 0.1%

Also verified end to end: with these libraries in place, a Unity 6000.3 IL2CPP Android build produces an APK where all 35 64-bit native libraries are 16 KB aligned, and the QuickJS backend loads and runs scripts on device.

`armeabi-v7a` is unaffected — the requirement applies to 64-bit ABIs only.
