### PR TITLE
fix libPapiQuickjs.so import settings for Android

### DIFF
--- a/unity/upms/quickjs/Plugins/Android/libs/arm64-v8a/libPapiQuickjs.so.meta
+++ b/unity/upms/quickjs/Plugins/Android/libs/arm64-v8a/libPapiQuickjs.so.meta
@@ -12,16 +12,61 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any: 
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Android: Android
     second:
       enabled: 1
+      settings:
+        AndroidSharedLibraryType: Executable
+        CPU: ARM64
+  - first:
+      Any: 
+    second:
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
     second:
       enabled: 0
       settings:
+        CPU: AnyCPU
         DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/unity/upms/quickjs/Plugins/Android/libs/armeabi-v7a/libPapiQuickjs.so.meta
+++ b/unity/upms/quickjs/Plugins/Android/libs/armeabi-v7a/libPapiQuickjs.so.meta
@@ -29,7 +29,7 @@ PluginImporter:
       enabled: 1
       settings:
         AndroidSharedLibraryType: Executable
-        CPU: ARM64
+        CPU: ARMv7
   - first:
       Any: 
     second:


### PR DESCRIPTION
### What

Fixes the Android plugin import settings for `libPapiQuickjs.so` in `unity/upms/quickjs`.

### Why

Two of the three ABIs are wrong, and the result is that the QuickJS backend cannot be loaded on a real device:

| meta | declares | should be |
|---|---|---|
| `arm64-v8a/libPapiQuickjs.so.meta` | no Android platform entry at all | `CPU: ARM64` |
| `armeabi-v7a/libPapiQuickjs.so.meta` | `CPU: ARM64` | `CPU: ARMv7` |
| `x86_64/libPapiQuickjs.so.meta` | `CPU: X86_64` | already correct |

Without an Android entry the arm64 library is not packaged into the APK at all, which is the ABI essentially every current Android device runs. And with `armeabi-v7a` claiming ARM64, two of the three ABIs claim arm64 and none claims ARMv7.

The build succeeds either way. The app then fails at the first script with:

```
DllNotFoundException: Unable to load DLL 'PapiQuickjs'
  dlerror() = dlopen failed: library "PapiQuickjs" not found
  at Puerts.ScriptEnv..ctor
```

### The fix

`libPuertsCore.so.meta` in `unity/upms/core` is correct for all three ABIs, so this simply brings the quickjs ones in line with it. After this change the three `libPapiQuickjs.so.meta` files are byte identical to the corresponding `libPuertsCore.so.meta` files apart from the `guid`.

Verified on device: with these settings, `libPapiQuickjs.so` is packaged for arm64-v8a and loads, and `ScriptEnv` constructs and runs scripts.

Worth noting that nothing in the editor catches this — no editor test loads the Android native libraries, so it only ever shows up on a real device.
