### PR TITLE
fix(unreal): use FProperty constructors without EObjectFlags on UE 5.8

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/ContainerMeta.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/ContainerMeta.cpp
@@ -9,6 +9,16 @@
 #include "ContainerMeta.h"
 #include "UObject/Package.h"
 
+// UE 5.8 deprecated the (Owner, Name, EObjectFlags) FField/FProperty constructors, and
+// FField::FlagsPrivate itself (superseded by FProperty::PropertyFlags, which this file already
+// sets via CPF_* below) -- so dropping RF_Transient for 5.8+ matches Epic's own migration
+// guidance, not just a warning suppression. Pre-5.8 engines keep the existing behavior.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+#define PUERTS_NEW_PROPERTY(Type, Owner, Name) new Type(Owner, Name)
+#else
+#define PUERTS_NEW_PROPERTY(Type, Owner, Name) new Type(Owner, Name, RF_Transient)
+#endif
+
 namespace PUERTS_NAMESPACE
 {
 FContainerMeta::FContainerMeta()
@@ -98,39 +108,39 @@ PropertyMacro* FContainerMeta::GetBuiltinProperty(BuiltinType type)
                 break;
 #elif ENGINE_MINOR_VERSION > 0 && ENGINE_MAJOR_VERSION > 4
             case TBool:
-                Ret = new FBoolProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FBoolProperty, PropertyMetaRoot, NAME_None);
                 static_cast<FBoolProperty*>(Ret)->SetBoolSize(1, true, 0xFF);
                 break;
             case TByte:
-                Ret = new FByteProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FByteProperty, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
             case TInt:
-                Ret = new FIntProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FIntProperty, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
             case TFloat:
-                Ret = new FFloatProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FFloatProperty, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
             case TDouble:
-                Ret = new FDoubleProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FDoubleProperty, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
             case TInt64:
-                Ret = new FInt64Property(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FInt64Property, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
             case TString:
-                Ret = new FStrProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FStrProperty, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
             case TText:
-                Ret = new FTextProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FTextProperty, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
             case TName:
-                Ret = new FNameProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                Ret = PUERTS_NEW_PROPERTY(FNameProperty, PropertyMetaRoot, NAME_None);
                 Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
                 break;
 #else
@@ -195,7 +205,7 @@ PropertyMacro* FContainerMeta::GetObjectProperty(UField* Field)
         Ret = new (EC_InternalUseOnlyConstructor, PropertyMetaRoot, NAME_None, RF_Transient)
             UObjectProperty(FObjectInitializer(), EC_CppProperty, 0, CPF_HasGetValueTypeHash, Class);
 #elif ENGINE_MINOR_VERSION > 0 && ENGINE_MAJOR_VERSION > 4
-        Ret = new FObjectProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+        Ret = PUERTS_NEW_PROPERTY(FObjectProperty, PropertyMetaRoot, NAME_None);
         static_cast<FObjectProperty*>(Ret)->PropertyClass = Class;
         Ret->PropertyFlags |= CPF_HasGetValueTypeHash;
 #else
@@ -208,7 +218,7 @@ PropertyMacro* FContainerMeta::GetObjectProperty(UField* Field)
         Ret = new (EC_InternalUseOnlyConstructor, PropertyMetaRoot, NAME_None, RF_Transient)
             UStructProperty(FObjectInitializer(), EC_CppProperty, 0, CPF_HasGetValueTypeHash, ScriptStruct);
 #elif ENGINE_MINOR_VERSION > 0 && ENGINE_MAJOR_VERSION > 4
-        Ret = new FStructProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+        Ret = PUERTS_NEW_PROPERTY(FStructProperty, PropertyMetaRoot, NAME_None);
         static_cast<FStructProperty*>(Ret)->Struct = ScriptStruct;
 #if ENGINE_MINOR_VERSION >= 5 && ENGINE_MAJOR_VERSION >= 5
         Ret->SetElementSize(ScriptStruct->PropertiesSize);
@@ -233,12 +243,12 @@ PropertyMacro* FContainerMeta::GetObjectProperty(UField* Field)
         {
             FEnumProperty* EnumProp =
 #if ENGINE_MAJOR_VERSION > 4 && ENGINE_MINOR_VERSION > 4    // 5.5+
-                new FEnumProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+                PUERTS_NEW_PROPERTY(FEnumProperty, PropertyMetaRoot, NAME_None);
             EnumProp->SetEnum(Enum);
 #else
                 new FEnumProperty(PropertyMetaRoot, NAME_None, RF_Transient, 0, CPF_HasGetValueTypeHash, Enum);
 #endif
-            FNumericProperty* UnderlyingProp = new FByteProperty(EnumProp, TEXT("UnderlyingType"), RF_Transient);
+            FNumericProperty* UnderlyingProp = PUERTS_NEW_PROPERTY(FByteProperty, EnumProp, TEXT("UnderlyingType"));
             EnumProp->AddCppProperty(UnderlyingProp);
 #if ENGINE_MINOR_VERSION >= 5 && ENGINE_MAJOR_VERSION >= 5
             EnumProp->SetElementSize(UnderlyingProp->GetElementSize());
@@ -251,7 +261,7 @@ PropertyMacro* FContainerMeta::GetObjectProperty(UField* Field)
         }
         else
         {
-            FByteProperty* ByteProp = new FByteProperty(PropertyMetaRoot, NAME_None, RF_Transient);
+            FByteProperty* ByteProp = PUERTS_NEW_PROPERTY(FByteProperty, PropertyMetaRoot, NAME_None);
             ByteProp->Enum = Enum;
 
             Ret = ByteProp;
@@ -272,6 +282,8 @@ PropertyMacro* FContainerMeta::GetObjectProperty(UField* Field)
     ObjectPropertyMap.Add(Field, Ret);
     return Ret;
 }
+
+#undef PUERTS_NEW_PROPERTY
 
 void FContainerMeta::NotifyElementTypeDeleted(const UField* Field)
 {


### PR DESCRIPTION
## Summary

UE 5.8 deprecates the `FField` / `FProperty` constructors that take an `EObjectFlags` argument. Every property created in `ContainerMeta.cpp` used that overload, so building the JsEnv module on 5.8 produced 14 `C4996` warnings with the note that the parameter must be removed before the next engine release. This PR switches those call sites to the two-argument constructor on 5.8 and later, and leaves earlier engines untouched.

## Changes

`ContainerMeta.cpp` only:

- A file-local macro `PUERTS_NEW_PROPERTY(Type, Owner, Name)` expands to `new Type(Owner, Name)` when `ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)`, and to the existing `new Type(Owner, Name, RF_Transient)` otherwise. It is `#undef`'d at the end of the file.
- The 14 `new F…Property(…, RF_Transient)` expressions (bool, byte, int, float, double, int64, string, text, name, object, struct, enum, the enum's underlying byte property, and the byte-enum property) now go through the macro.
- A comment explains why dropping `RF_Transient` on 5.8 is correct: 5.8 also deprecates `FField::FlagsPrivate`, which is superseded by `FProperty::PropertyFlags`, and this file already sets those via `CPF_*`.

No behaviour change is intended on any engine version.

## Verification

Full Development editor builds from a clean `Intermediate/` and `Binaries/` on Windows, Epic Launcher engines, default V8 9.4.146.24, warning lists compared line by line against the unmodified plugin:

- **UE 5.8:** build succeeds; the warning list goes from 55 to 41 unique lines. The 14 removed lines are exactly the `ContainerMeta.cpp` `C4996` warnings. No warning was added.
- **UE 5.7:** build succeeds; the warning list is identical to the unmodified plugin (53 lines).
- Editor sessions on both versions load the plugin and run the declaration generator and a TypeScript Blueprint class through PIE without regression.

## Notes for reviewers

- The macro exists only to keep the version check in one place; each call site is otherwise a one-line change.
- The change is independent of the reserved-word declaration fix submitted separately; the two apply cleanly in either order.

