### PR TITLE
fix(unreal): drop REN_ForceNoResetLoaders on UE 5.8

### DIFF
--- a/unreal/Puerts/Source/JsEnv/Private/JSGeneratedClass.cpp
+++ b/unreal/Puerts/Source/JsEnv/Private/JSGeneratedClass.cpp
@@ -12,6 +12,14 @@
 #include "JSWidgetGeneratedClass.h"
 #include "JSLogger.h"
 
+// UE 5.8 deprecates REN_ForceNoResetLoaders: UObject::Rename no longer calls ResetLoaders, so the flag has no effect
+// there. Earlier engines keep it, where Rename would otherwise reset the package loaders.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+#define PUERTS_RENAME_FLAGS (REN_DontCreateRedirectors | REN_DoNotDirty)
+#else
+#define PUERTS_RENAME_FLAGS (REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders)
+#endif
+
 #define OLD_METHOD_PREFIX "__puerts_old__"
 #define MIXIN_METHOD_SUFFIX "__puerts_mixin__"
 
@@ -101,8 +109,7 @@ void UJSGeneratedClass::Override(v8::Isolate* Isolate, UClass* Class, UFunction*
         }
         // UE_LOG(LogTemp, Error, TEXT("replace %s of %s"), *Super->GetName(), *Class->GetName());
         //同一Outer下的同名对象只能有一个...
-        Super->Rename(*FString::Printf(TEXT("%s%s"), TEXT(OLD_METHOD_PREFIX), *Super->GetName()), Class,
-            REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders);
+        Super->Rename(*FString::Printf(TEXT("%s%s"), TEXT(OLD_METHOD_PREFIX), *Super->GetName()), Class, PUERTS_RENAME_FLAGS);
         Class->AddFunctionToFunctionMap(Super, Super->GetFName());
         // UE_LOG(LogTemp, Error, TEXT("rename to %s"), *Super->GetName());
     }
@@ -317,7 +324,7 @@ void UJSGeneratedClass::Restore(UClass* Class)
             {
                 JGF->RemoveFromRoot();
             }
-            JGF->Rename(nullptr, OrphanedClass, REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders);
+            JGF->Rename(nullptr, OrphanedClass, PUERTS_RENAME_FLAGS);
             FLinkerLoad::InvalidateExport(JGF);
         }
         else
@@ -337,8 +344,7 @@ void UJSGeneratedClass::Restore(UClass* Class)
             if (Function->GetName().StartsWith(TEXT(OLD_METHOD_PREFIX)))
             {
                 Class->RemoveFunctionFromFunctionMap(Function);
-                Function->Rename(*Function->GetName().Mid(strlen(OLD_METHOD_PREFIX)), Class,
-                    REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders);
+                Function->Rename(*Function->GetName().Mid(strlen(OLD_METHOD_PREFIX)), Class, PUERTS_RENAME_FLAGS);
                 Class->AddFunctionToFunctionMap(Function, Function->GetFName());
             }
         }
@@ -379,3 +385,5 @@ void UJSGeneratedClass::Release()
     Constructor.Reset();
     Prototype.Reset();
 }
+
+#undef PUERTS_RENAME_FLAGS

--- a/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
+++ b/unreal/Puerts/Source/PuertsEditor/Private/PEBlueprintAsset.cpp
@@ -45,6 +45,14 @@
 #include "Framework/Application/SlateApplication.h"
 #include "Misc/MessageDialog.h"
 
+// UE 5.8 deprecates REN_ForceNoResetLoaders: UObject::Rename no longer calls ResetLoaders, so the flag has no effect
+// there. Earlier engines keep it, where Rename would otherwise reset the package loaders.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+#define PUERTS_RENAME_FLAGS (REN_DontCreateRedirectors | REN_DoNotDirty)
+#else
+#define PUERTS_RENAME_FLAGS (REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders)
+#endif
+
 #define LOCTEXT_NAMESPACE "UPEBlueprintAsset"
 
 DEFINE_LOG_CATEGORY_STATIC(PuertsEditorModule, Log, All);
@@ -556,8 +564,8 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
                 UEdGraph* ExistingGraph = FindObject<UEdGraph>(Blueprint, *(InName.ToString()));
                 if (ExistingGraph)
                 {
-                    ExistingGraph->Rename(*FString::Printf(TEXT("%s%s"), *ExistingGraph->GetName(), TEXT("__Removed")), nullptr,
-                        REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders);
+                    ExistingGraph->Rename(
+                        *FString::Printf(TEXT("%s%s"), *ExistingGraph->GetName(), TEXT("__Removed")), nullptr, PUERTS_RENAME_FLAGS);
                 }
 
                 UK2Node_CustomEvent* EventNode = FEdGraphSchemaAction_K2NewNode::SpawnNode<UK2Node_CustomEvent>(EventGraph,
@@ -608,8 +616,8 @@ void UPEBlueprintAsset::AddFunction(FName InName, bool IsVoid, FPEGraphPinType I
                 UEdGraph* ExistingGraph = FindObject<UEdGraph>(Blueprint, *(InName.ToString()));
                 if (ExistingGraph)
                 {
-                    ExistingGraph->Rename(*FString::Printf(TEXT("%s%s"), *ExistingGraph->GetName(), TEXT("__Removed")), nullptr,
-                        REN_DontCreateRedirectors | REN_DoNotDirty | REN_ForceNoResetLoaders);
+                    ExistingGraph->Rename(
+                        *FString::Printf(TEXT("%s%s"), *ExistingGraph->GetName(), TEXT("__Removed")), nullptr, PUERTS_RENAME_FLAGS);
                 }
             }
             FunctionGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint,
@@ -1397,3 +1405,5 @@ void UPEBlueprintAsset::Save()
     }
     FunctionAdded.Empty();
 }
+
+#undef PUERTS_RENAME_FLAGS


### PR DESCRIPTION
## Summary

UE 5.8 deprecates `REN_ForceNoResetLoaders` (`C4996`: "Rename will no longer call ResetLoaders making this flag no longer needed … your project will no longer compile" on the next release). The plugin passes it in five `Rename` calls, three in `JSGeneratedClass.cpp` and two in `PEBlueprintAsset.cpp`. This PR omits the flag on 5.8 and later and keeps it on earlier engines.

## Why omit rather than replace

The deprecation note suggests `REN_AllowPackageLinkerMismatch`. That flag is not a substitute for these call sites:

- On 5.8 (and already on 5.7) `UObject::Rename` does not read `REN_ForceNoResetLoaders` at all, so omitting it changes nothing.
- `REN_AllowPackageLinkerMismatch` does have effects: it keeps the object's linker when it is moved to another package, and on 5.8 it suppresses the new editor-only detach of a loaded object's export on an in-place rename. None of the five calls wants either. Two rename a `UFunction` in place within the same class (`Override`, `Restore`), one moves a function to the orphan class and already calls `FLinkerLoad::InvalidateExport` on it, and two rename a `UEdGraph` in place to `<name>__Removed`.
- Engine versions before 5.x could reset loaders in `Rename` unless this flag was set, so the flag is kept there.

